### PR TITLE
feat(.github): set up pull request template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,26 @@
+# Description
+
+<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->
+
+Closes # (issue) <!-- Remove if not linked to an issue -->
+
+## Type of change
+
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+- [ ] Manual testing (requires screenshots or videos)
+
+## Checklist before requesting a review
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have commented my code in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation if needed
+- [ ] I have added thorough tests that prove my fix is effective and that my feature works
+- [ ] I've requested a review from another team member


### PR DESCRIPTION
Adds a `.github/pull-request-template.md` to standardise how PRs are described across the team. Going forward, opening a new PR on GitHub will automatically pre-populate the description with sections for:

- A summary of changes and linked issue
- Type of change (bug fix, feature, breaking change, docs)
- Testing evidence
- A pre-review checklist