### PR TITLE
feat(.github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend-feature-template.md
+++ b/.github/ISSUE_TEMPLATE/backend-feature-template.md
@@ -1,0 +1,27 @@
+---
+name: Backend feature template
+about: Features relating to the backend
+title: "[BACKEND]"
+labels: ''
+assignees: ''
+type: Feature
+
+---
+
+### Is your feature request related to a problem? Please describe
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered, if applicable. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here, if applicable. -->
+
+### BEFORE MERGING
+
+- [ ] Code generation run (*hint*: `pnpm typegen`)
+- [ ] PR Reviewed (For non-trivial changes)
+- [ ] All required PR checks passing

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Unexpecting or breaking behaviour
+title: "[BUG]"
+labels: bug
+assignees: ''
+type: Bug
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/devops-feature-template.md
+++ b/.github/ISSUE_TEMPLATE/devops-feature-template.md
@@ -1,0 +1,30 @@
+---
+name: DevOps feature template
+about: Features relating to the development operations
+title: "[DEVOPS]"
+labels: ''
+assignees: ''
+type: Feature
+
+---
+
+### Is your feature request related to a problem? Please describe
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->
+
+### Acceptance Criteria
+<!-- Define the acceptance criteria for the feature -->
+
+### BEFORE MERGING
+
+- [ ] Acceptance criteria met
+- [ ] PR Reviewed (For non-trivial changes)
+- [ ] All required PR checks passing

--- a/.github/ISSUE_TEMPLATE/frontend-feature-template.md
+++ b/.github/ISSUE_TEMPLATE/frontend-feature-template.md
@@ -1,0 +1,26 @@
+---
+name: Frontend feature template
+about: Features relating to the frontend
+title: "[FRONTEND]"
+labels: ''
+assignees: ''
+type: Feature
+
+---
+
+### Is your feature request related to a problem? Please describe
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered, if applicable. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here, if applicable. -->
+
+### BEFORE MERGING
+
+- [ ] PR Reviewed (For non-trivial changes)
+- [ ] All required PR checks passing


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

- Added four GitHub issue templates to standardize how issues are reported and requested across the project
- Bug report — structured template with reproduction steps, expected behaviour, environment info (desktop/mobile), and additional context
- Backend feature — feature request template scoped to backend work, with a pre-merge checklist including `pnpm typegen` code generation
- Frontend feature — feature request template scoped to frontend work, with a pre-merge checklist
- DevOps feature — feature request template scoped to DevOps/infrastructure work, with acceptance criteria and a pre-merge checklist

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member
