### PR TITLE
AutoBot Fix: [GitHub] [BACKEND] Create executives collection

### DIFF
--- a/src/payload/collections/Executives.ts
+++ b/src/payload/collections/Executives.ts
@@ -1,0 +1,40 @@
+import type { CollectionConfig } from 'payload'
+
+export const Executives: CollectionConfig = {
+  slug: 'executives',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'title', 'createdAt'],
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'bio',
+      type: 'textarea',
+    },
+    {
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
+    },
+    {
+      name: 'order',
+      type: 'number',
+      admin: {
+        position: 'sidebar',
+      },
+    },
+  ],
+}


### PR DESCRIPTION
This PR was autonomously generated by AutoBot via OpenRouter to address [GitHub] [BACKEND] Create executives collection.

### Description
**Is your feature request related to a problem? Please describe**

There is no way for admins to manage executive team member profiles through the CMS...