### PR TITLE
refactor(payload): split events collection into events and social sessions

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
     executives: Executive;
     faqs: Faq;
     events: Event;
+    'social-sessions': SocialSession;
     'event-registrations': EventRegistration;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -88,6 +89,7 @@ export interface Config {
     executives: ExecutivesSelect<false> | ExecutivesSelect<true>;
     faqs: FaqsSelect<false> | FaqsSelect<true>;
     events: EventsSelect<false> | EventsSelect<true>;
+    'social-sessions': SocialSessionsSelect<false> | SocialSessionsSelect<true>;
     'event-registrations': EventRegistrationsSelect<false> | EventRegistrationsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -299,6 +301,87 @@ export interface Event {
   createdAt: string;
 }
 /**
+ * Weekly club social sessions with registration, capacity limits, and pricing.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "social-sessions".
+ */
+export interface SocialSession {
+  id: string;
+  /**
+   * Public-facing title of the social session.
+   */
+  title: string;
+  /**
+   * Full description shown on the social session page.
+   */
+  description: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  /**
+   * Date the session takes place.
+   */
+  date: string;
+  /**
+   * Start time, e.g. '7:00pm'.
+   */
+  startTime: string;
+  /**
+   * End time, e.g. '9:00pm'.
+   */
+  endTime?: string | null;
+  /**
+   * Venue or address for the session.
+   */
+  location: string;
+  /**
+   * Optional cover image for the session card.
+   */
+  image?: (string | null) | Media;
+  /**
+   * Maximum number of confirmed registrations before new sign-ups go to the waitlist.
+   */
+  maxCapacity: number;
+  /**
+   * Maximum number of waitlisted registrations. Set to 0 to disable the waitlist.
+   */
+  waitlistCapacity: number;
+  /**
+   * Price charged to authenticated club members. Leave blank for free.
+   */
+  memberPrice?: number | null;
+  /**
+   * Price charged to guests (non-members). Leave blank for free.
+   */
+  nonMemberPrice?: number | null;
+  /**
+   * When registration opens. Registrations before this time are rejected.
+   */
+  registrationOpenAt?: string | null;
+  /**
+   * When registration closes. Registrations after this time are rejected.
+   */
+  registrationCloseAt?: string | null;
+  /**
+   * Lifecycle state of the session.
+   */
+  status: 'upcoming' | 'ongoing' | 'completed' | 'cancelled';
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "event-registrations".
  */
@@ -362,6 +445,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'events';
         value: string | Event;
+      } | null)
+    | ({
+        relationTo: 'social-sessions';
+        value: string | SocialSession;
       } | null)
     | ({
         relationTo: 'event-registrations';
@@ -518,6 +605,28 @@ export interface EventsSelect<T extends boolean = true> {
   title?: T;
   description?: T;
   eventType?: T;
+  date?: T;
+  startTime?: T;
+  endTime?: T;
+  location?: T;
+  image?: T;
+  maxCapacity?: T;
+  waitlistCapacity?: T;
+  memberPrice?: T;
+  nonMemberPrice?: T;
+  registrationOpenAt?: T;
+  registrationCloseAt?: T;
+  status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "social-sessions_select".
+ */
+export interface SocialSessionsSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
   date?: T;
   startTime?: T;
   endTime?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -263,12 +263,20 @@ export interface Faq {
   createdAt: string;
 }
 /**
+ * Display-only event cards. Sign-ups go to an external Google Form via googleFormUrl.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "events".
  */
 export interface Event {
   id: string;
+  /**
+   * Public-facing title of the event.
+   */
   title: string;
+  /**
+   * Full description shown on the event card.
+   */
   description: {
     root: {
       type: string;
@@ -284,19 +292,34 @@ export interface Event {
     };
     [k: string]: unknown;
   };
-  eventType: 'social-session' | 'event';
+  /**
+   * Date the event takes place.
+   */
   date: string;
+  /**
+   * Start time, e.g. '7:00pm'.
+   */
   startTime: string;
+  /**
+   * End time, e.g. '9:00pm'.
+   */
   endTime?: string | null;
+  /**
+   * Venue or address for the event.
+   */
   location: string;
+  /**
+   * Optional cover image for the event card.
+   */
   image?: (string | null) | Media;
-  maxCapacity: number;
-  waitlistCapacity?: number | null;
-  memberPrice?: number | null;
-  nonMemberPrice?: number | null;
-  registrationOpenAt?: string | null;
-  registrationCloseAt?: string | null;
-  status: 'upcoming' | 'ongoing' | 'completed' | 'cancelled';
+  /**
+   * External Google Form URL for sign-ups. Event card will link out to this URL.
+   */
+  googleFormUrl?: string | null;
+  /**
+   * Lifecycle state of the event.
+   */
+  status: 'upcoming' | 'completed' | 'cancelled';
   updatedAt: string;
   createdAt: string;
 }
@@ -604,18 +627,12 @@ export interface FaqsSelect<T extends boolean = true> {
 export interface EventsSelect<T extends boolean = true> {
   title?: T;
   description?: T;
-  eventType?: T;
   date?: T;
   startTime?: T;
   endTime?: T;
   location?: T;
   image?: T;
-  maxCapacity?: T;
-  waitlistCapacity?: T;
-  memberPrice?: T;
-  nonMemberPrice?: T;
-  registrationOpenAt?: T;
-  registrationCloseAt?: T;
+  googleFormUrl?: T;
   status?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,6 +11,7 @@ import { Events } from "./payload/collections/Events"
 import { Executives } from "./payload/collections/Executives"
 import { FAQs } from "./payload/collections/FAQs"
 import { Media } from "./payload/collections/Media"
+import { SocialSessions } from "./payload/collections/SocialSessions"
 import { Users } from "./payload/collections/Users"
 
 const filename = fileURLToPath(import.meta.url)
@@ -23,7 +24,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Admin, Users, Media, Executives, FAQs, Events, EventRegistrations],
+  collections: [Admin, Users, Media, Executives, FAQs, Events, SocialSessions, EventRegistrations],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || "",
   typescript: {

--- a/src/payload/collections/Events.ts
+++ b/src/payload/collections/Events.ts
@@ -1,5 +1,9 @@
 import type { CollectionConfig } from "payload"
 
+// Events — display-only event cards. Sign-ups are handled externally via a
+// Google Form linked from each card. For registrable on-site sessions with
+// capacity, waitlist, and payment, see the SocialSessions collection.
+
 type AdminCheckArgs = {
   req: {
     user?: {
@@ -10,14 +14,8 @@ type AdminCheckArgs = {
 
 const isAdmin = ({ req }: AdminCheckArgs) => req.user?.collection === "admin"
 
-const eventTypeOptions = [
-  { label: "Social Session", value: "social-session" },
-  { label: "Event", value: "event" },
-]
-
 const statusOptions = [
   { label: "Upcoming", value: "upcoming" },
-  { label: "Ongoing", value: "ongoing" },
   { label: "Completed", value: "completed" },
   { label: "Cancelled", value: "cancelled" },
 ]
@@ -26,10 +24,11 @@ export const Events: CollectionConfig = {
   slug: "events",
   admin: {
     useAsTitle: "title",
-    defaultColumns: ["title", "eventType", "date", "location", "status", "updatedAt"],
+    defaultColumns: ["title", "date", "location", "status", "updatedAt"],
+    description:
+      "Display-only event cards. Sign-ups go to an external Google Form via googleFormUrl.",
   },
   access: {
-    // Anyone can see events, only admins can add, edit, or remove them
     read: () => true,
     create: isAdmin,
     update: isAdmin,
@@ -40,67 +39,49 @@ export const Events: CollectionConfig = {
       name: "title",
       type: "text",
       required: true,
+      admin: { description: "Public-facing title of the event." },
     },
     {
       name: "description",
       type: "richText",
       required: true,
-    },
-    {
-      name: "eventType",
-      type: "select",
-      required: true,
-      options: eventTypeOptions,
+      admin: { description: "Full description shown on the event card." },
     },
     {
       name: "date",
       type: "date",
       required: true,
+      admin: { description: "Date the event takes place." },
     },
     {
       name: "startTime",
       type: "text",
       required: true,
+      admin: { description: "Start time, e.g. '7:00pm'." },
     },
     {
       name: "endTime",
       type: "text",
+      admin: { description: "End time, e.g. '9:00pm'." },
     },
     {
       name: "location",
       type: "text",
       required: true,
+      admin: { description: "Venue or address for the event." },
     },
     {
       name: "image",
       type: "upload",
       relationTo: "media",
+      admin: { description: "Optional cover image for the event card." },
     },
     {
-      name: "maxCapacity",
-      type: "number",
-      required: true,
-    },
-    {
-      name: "waitlistCapacity",
-      type: "number",
-      defaultValue: 0,
-    },
-    {
-      name: "memberPrice",
-      type: "number",
-    },
-    {
-      name: "nonMemberPrice",
-      type: "number",
-    },
-    {
-      name: "registrationOpenAt",
-      type: "date",
-    },
-    {
-      name: "registrationCloseAt",
-      type: "date",
+      name: "googleFormUrl",
+      type: "text",
+      admin: {
+        description: "External Google Form URL for sign-ups. Event card will link out to this URL.",
+      },
     },
     {
       name: "status",
@@ -108,6 +89,7 @@ export const Events: CollectionConfig = {
       required: true,
       defaultValue: "upcoming",
       options: statusOptions,
+      admin: { description: "Lifecycle state of the event." },
     },
   ],
 }

--- a/src/payload/collections/SocialSessions.ts
+++ b/src/payload/collections/SocialSessions.ts
@@ -1,0 +1,136 @@
+import type { CollectionConfig } from "payload"
+
+// SocialSessions — registrable weekly club sessions with capacity, waitlist,
+// and member/non-member pricing. Registrations are made on-site through the
+// SocialSessionRegistrations collection (planned) and can be paid via Stripe.
+
+type AdminCheckArgs = {
+  req: {
+    user?: {
+      collection?: string
+    } | null
+  }
+}
+
+const isAdmin = ({ req }: AdminCheckArgs) => req.user?.collection === "admin"
+
+const statusOptions = [
+  { label: "Upcoming", value: "upcoming" },
+  { label: "Ongoing", value: "ongoing" },
+  { label: "Completed", value: "completed" },
+  { label: "Cancelled", value: "cancelled" },
+]
+
+export const SocialSessions: CollectionConfig = {
+  slug: "social-sessions",
+  admin: {
+    useAsTitle: "title",
+    defaultColumns: ["title", "date", "location", "maxCapacity", "status", "updatedAt"],
+    description: "Weekly club social sessions with registration, capacity limits, and pricing.",
+  },
+  access: {
+    read: () => true,
+    create: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      required: true,
+      admin: { description: "Public-facing title of the social session." },
+    },
+    {
+      name: "description",
+      type: "richText",
+      required: true,
+      admin: { description: "Full description shown on the social session page." },
+    },
+    {
+      name: "date",
+      type: "date",
+      required: true,
+      admin: { description: "Date the session takes place." },
+    },
+    {
+      name: "startTime",
+      type: "text",
+      required: true,
+      admin: { description: "Start time, e.g. '7:00pm'." },
+    },
+    {
+      name: "endTime",
+      type: "text",
+      admin: { description: "End time, e.g. '9:00pm'." },
+    },
+    {
+      name: "location",
+      type: "text",
+      required: true,
+      admin: { description: "Venue or address for the session." },
+    },
+    {
+      name: "image",
+      type: "upload",
+      relationTo: "media",
+      admin: { description: "Optional cover image for the session card." },
+    },
+    {
+      name: "maxCapacity",
+      type: "number",
+      required: true,
+      defaultValue: 40,
+      admin: {
+        description:
+          "Maximum number of confirmed registrations before new sign-ups go to the waitlist.",
+      },
+    },
+    {
+      name: "waitlistCapacity",
+      type: "number",
+      required: true,
+      defaultValue: 0,
+      admin: {
+        description:
+          "Maximum number of waitlisted registrations. Set to 0 to disable the waitlist.",
+      },
+    },
+    {
+      name: "memberPrice",
+      type: "number",
+      admin: {
+        description: "Price charged to authenticated club members. Leave blank for free.",
+      },
+    },
+    {
+      name: "nonMemberPrice",
+      type: "number",
+      admin: {
+        description: "Price charged to guests (non-members). Leave blank for free.",
+      },
+    },
+    {
+      name: "registrationOpenAt",
+      type: "date",
+      admin: {
+        description: "When registration opens. Registrations before this time are rejected.",
+      },
+    },
+    {
+      name: "registrationCloseAt",
+      type: "date",
+      admin: {
+        description: "When registration closes. Registrations after this time are rejected.",
+      },
+    },
+    {
+      name: "status",
+      type: "select",
+      required: true,
+      defaultValue: "upcoming",
+      options: statusOptions,
+      admin: { description: "Lifecycle state of the session." },
+    },
+  ],
+}


### PR DESCRIPTION
# Description

This PR splits the `Events` collection into two collections: a display-only `Events` collection that links out to an external Google Form, and a new `SocialSessions` collection that owns the on-site registration flow (capacity, waitlist, pricing, registration windows). Events and social sessions were previously conflated, which forced registration-specific fields onto event records and would have complicated future validation hooks.

- adds a new `SocialSessions` collection at `src/payload/collections/SocialSessions.ts` with fields `title`, `description`, `date`, `startTime`, `endTime`, `location`, `image`, `maxCapacity` (default 40), `waitlistCapacity`, `memberPrice`, `nonMemberPrice`, `registrationOpenAt`, `registrationCloseAt`, and `status`
- registers `SocialSessions` in `src/payload.config.ts`
- strips the `Events` collection down to display-only fields: removes `eventType`, `maxCapacity`, `waitlistCapacity`, `memberPrice`, `nonMemberPrice`, `registrationOpenAt`, and `registrationCloseAt`
- adds a `googleFormUrl` text field to `Events` for linking out to an external sign-up form
- drops the `ongoing` option from the `Events` `status` select (kept on `SocialSessions`)
- adds admin `description` text to both collections and to every field for CMS clarity
- regenerates `src/payload-types.ts` via `pnpm typegen`

Both collections allow public `read` and restrict `create`/`update`/`delete` to admins via the existing `isAdmin` check.

Closes #38

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Note that this is schema-breaking for any existing `events` records that rely on the removed registration fields. Those records should be migrated to `social-sessions` before merge.

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

Run `pnpm dev` and sign in to the Payload admin panel. Verify:

- the sidebar shows both `Events` and `Social Sessions` collections
- creating an `Event` only exposes the display-only fields plus `googleFormUrl`, and the `status` select no longer offers `Ongoing`
- creating a `Social Session` exposes the full registration flow (`maxCapacity` defaults to 40, `waitlistCapacity` defaults to 0, both prices and registration window fields are present) and the `status` select still includes `Ongoing`
- public `read` still works and `create`/`update`/`delete` are blocked for non-admin users
- `pnpm typegen` produces no diff and `pnpm tsc --noEmit` passes

I would recommend checking that the admin descriptions render correctly under each field in the CMS, since those are the main UX signal for content editors picking the right collection.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member