### PR TITLE
chore(payload): add admin descriptions to remaining collections

### DIFF
--- a/src/payload/collections/Admin.ts
+++ b/src/payload/collections/Admin.ts
@@ -1,9 +1,13 @@
 import type { CollectionConfig } from "payload"
 
+// Admin — authentication collection for club executives who manage the CMS.
+// Separate from the Users collection (which is for regular club members).
+
 export const Admin: CollectionConfig = {
   slug: "admin",
   admin: {
     useAsTitle: "email",
+    description: "Club executive accounts with full CMS access.",
   },
   auth: true,
   fields: [

--- a/src/payload/collections/Executives.ts
+++ b/src/payload/collections/Executives.ts
@@ -1,10 +1,13 @@
 import type { CollectionConfig } from "payload"
 
+// Executives — club committee profiles displayed on the executive team page.
+
 export const Executives: CollectionConfig = {
   slug: "executives",
   admin: {
     useAsTitle: "name",
     defaultColumns: ["name", "role", "order", "updatedAt"],
+    description: "Club executive profiles shown on the public Executive Team page.",
   },
   access: {
     read: () => true,
@@ -14,27 +17,38 @@ export const Executives: CollectionConfig = {
       name: "name",
       type: "text",
       required: true,
+      admin: { description: "Full name of the executive." },
     },
     {
       name: "role",
       type: "text",
       required: true,
+      admin: {
+        description: "Role title, e.g. 'President', 'Treasurer', 'Social Coordinator'.",
+      },
     },
     {
       name: "bio",
       type: "textarea",
       required: false,
+      admin: {
+        description: "Short biography displayed on the executive's profile card.",
+      },
     },
     {
       name: "photo",
       type: "upload",
       relationTo: "media",
       required: false,
+      admin: { description: "Profile photo for the executive's card." },
     },
     {
       name: "order",
       type: "number",
       required: false,
+      admin: {
+        description: "Display order on the executive team page. Lower numbers appear first.",
+      },
     },
   ],
 }

--- a/src/payload/collections/FAQs.ts
+++ b/src/payload/collections/FAQs.ts
@@ -1,28 +1,42 @@
 import type { CollectionConfig } from "payload"
 
+// FAQs — frequently asked questions displayed on the public FAQ page.
+// Published FAQs are visible to everyone; unpublished ones are admin-only.
+
 export const FAQs: CollectionConfig = {
   slug: "faqs",
+  admin: {
+    description: "Frequently asked questions shown on the public FAQ page.",
+  },
   fields: [
     {
       name: "question",
       type: "text",
       required: true,
+      admin: { description: "The question, shown as the FAQ entry heading." },
     },
     {
       name: "answer",
       type: "richText",
       required: true,
+      admin: { description: "The answer, supports rich formatting and links." },
     },
     {
       name: "order",
       type: "number",
       required: false,
+      admin: {
+        description: "Display order on the FAQ page. Lower numbers appear first.",
+      },
     },
     {
       name: "published",
       type: "checkbox",
       required: true,
       defaultValue: true,
+      admin: {
+        description: "If unchecked, this FAQ is hidden from the public and visible only to admins.",
+      },
     },
   ],
   access: {

--- a/src/payload/collections/Media.ts
+++ b/src/payload/collections/Media.ts
@@ -1,7 +1,13 @@
 import type { CollectionConfig } from "payload"
 
+// Media — uploaded images used across the site (event cards, executive
+// headshots, social session covers, etc.).
+
 export const Media: CollectionConfig = {
   slug: "media",
+  admin: {
+    description: "Uploaded images referenced by events, social sessions, and executives.",
+  },
   access: {
     read: () => true,
   },
@@ -10,6 +16,9 @@ export const Media: CollectionConfig = {
       name: "alt",
       type: "text",
       required: true,
+      admin: {
+        description: "Alt text describing the image for screen readers and accessibility.",
+      },
     },
   ],
   upload: true,

--- a/src/payload/collections/Users.ts
+++ b/src/payload/collections/Users.ts
@@ -1,9 +1,14 @@
 import type { CollectionConfig } from "payload"
 
+// Users — authentication collection for regular club members who register
+// through the website frontend. Members cannot access the CMS; for that see
+// the Admin collection.
+
 export const Users: CollectionConfig = {
   slug: "users",
   admin: {
     useAsTitle: "email",
+    description: "Club member accounts used for social session registration.",
   },
   auth: {
     tokenExpiration: 43200,
@@ -27,19 +32,25 @@ export const Users: CollectionConfig = {
       name: "firstName",
       type: "text",
       required: true,
+      admin: { description: "Member's first name." },
     },
     {
       name: "lastName",
       type: "text",
       required: true,
+      admin: { description: "Member's last name." },
     },
     {
       name: "upi",
       type: "text",
+      admin: {
+        description: "University of Auckland UPI, if the member is a UoA student.",
+      },
     },
     {
       name: "phone",
       type: "text",
+      admin: { description: "Contact phone number." },
     },
   ],
 }


### PR DESCRIPTION
# Description

This PR adds `admin.description` metadata and file-header comments to the five Payload collections that were missing them, so non-developer CMS users (the club exec team) can navigate and edit content without asking a developer.

- adds a collection-level `admin.description` to `Admin`, `Users`, `Media`, `Executives`, and `FAQs` (renders as a subtitle in the Payload sidebar)
- adds per-field `admin.description` to every user-editable field in those five collections (renders as grey helper text beneath each input in the edit form)
- adds a short file-header comment to each of the five collection files summarising what the collection represents and, where relevant, how it differs from related collections (i.e. `Admin` vs `Users`)

Note that the other three collections (`Events`, `SocialSessions`, `SocialSessionRegistrations`) already received these descriptions in prior refactors (#40, #41), so this PR closes the gap across all 8 collections.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

In the Payload admin UI (`/admin`):

- open the sidebar and confirm `Admin`, `Users`, `Media`, `Executives`, and `FAQs` each display a subtitle under the collection name
- open a document in each of those collections and confirm every field shows grey helper text beneath the input describing what it is for
- cross-check against `Events`, `SocialSessions`, and `SocialSessionRegistrations` to confirm the styling is consistent with the descriptions already added in #40 and #41

Note that `pnpm typegen` was intentionally not run — no schema fields were added, renamed, or changed, only `admin` UI metadata — so no generated types need updating. TypeScript compiles cleanly.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member