### PR TITLE
feat(frontend): configure global Tailwind theme from Figma

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -1,1 +1,14 @@
 @import "tailwindcss";
+
+@theme {
+  --color-brand-primary: #004cb3;
+  --color-brand-yellow: #ffbe00;
+  --color-brand-navy: #08345b;
+  --color-brand-light-blue: #93dbf4;
+  --color-brand-light-grey: #edebe8;
+}
+
+@theme inline {
+  --font-heading: var(--font-staatliches);
+  --font-body: var(--font-inter);
+}

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,5 +1,19 @@
+import { Inter, Staatliches } from "next/font/google"
 import type React from "react"
 import "./globals.css"
+
+const staatliches = Staatliches({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-staatliches",
+  weight: "400",
+})
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+})
 
 export const metadata = {
   description: "A blank template using Payload in a Next.js app.",
@@ -10,8 +24,8 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
   const { children } = props
 
   return (
-    <html lang="en">
-      <body>
+    <html className={`${staatliches.variable} ${inter.variable} antialiased`} lang="en">
+      <body className="font-body">
         <main>{children}</main>
       </body>
     </html>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR adds the global Tailwind v4 theme tokens for the frontend using the colours and fonts of the UOAVC Figma design.

- added global brand colour tokens in `src/app/(frontend)/globals.css`
- added global font tokens for heading and body fonts using `@theme inline`, with `Staatliches` as the heading font and `Inter` as the body font
- updated `src/app/(frontend)/layout.tsx` to load and apply the fonts with `next/font/google`

[Figma](https://www.figma.com/design/1A1QnfEVJgAdvOyB49iGX1/UOAVC-Design?node-id=0-1&t=lL9HH0s08yDAnGP8-1)

Closes #43

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

Tested locally by running `pnpm dev` and confirming:
- `font-heading` maps to `Staatliches`
- `font-body` maps to `Inter`
- global colour token classes render correctly when applied in the frontend
- the page loads successfully

<img width="1173" height="470" alt="image" src="https://github.com/user-attachments/assets/e78d22df-f279-4d62-ba86-3bd31c048671" />
<img width="1186" height="466" alt="image" src="https://github.com/user-attachments/assets/4261d128-d0ab-46c7-8cb4-323aa4a5c3a8" />
<img width="1384" height="170" alt="image" src="https://github.com/user-attachments/assets/c25c7180-4ac3-4e32-b107-8e9f6ac80e88" />

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member