### PR TITLE
Feat/14 social session availability endpoint

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -149,6 +149,8 @@ export interface UserAuthOperations {
   };
 }
 /**
+ * Club executive accounts with full CMS access.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "admin".
  */
@@ -174,14 +176,28 @@ export interface Admin {
   collection: 'admin';
 }
 /**
+ * Club member accounts used for social session registration.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
   id: string;
+  /**
+   * Member's first name.
+   */
   firstName: string;
+  /**
+   * Member's last name.
+   */
   lastName: string;
+  /**
+   * University of Auckland UPI, if the member is a UoA student.
+   */
   upi?: string | null;
+  /**
+   * Contact phone number.
+   */
   phone?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -203,11 +219,16 @@ export interface User {
   collection: 'users';
 }
 /**
+ * Uploaded images referenced by events, social sessions, and executives.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
 export interface Media {
   id: string;
+  /**
+   * Alt text describing the image for screen readers and accessibility.
+   */
   alt: string;
   updatedAt: string;
   createdAt: string;
@@ -222,26 +243,51 @@ export interface Media {
   focalY?: number | null;
 }
 /**
+ * Club executive profiles shown on the public Executive Team page.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "executives".
  */
 export interface Executive {
   id: string;
+  /**
+   * Full name of the executive.
+   */
   name: string;
+  /**
+   * Role title, e.g. 'President', 'Treasurer', 'Social Coordinator'.
+   */
   role: string;
+  /**
+   * Short biography displayed on the executive's profile card.
+   */
   bio?: string | null;
+  /**
+   * Profile photo for the executive's card.
+   */
   photo?: (string | null) | Media;
+  /**
+   * Display order on the executive team page. Lower numbers appear first.
+   */
   order?: number | null;
   updatedAt: string;
   createdAt: string;
 }
 /**
+ * Frequently asked questions shown on the public FAQ page.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "faqs".
  */
 export interface Faq {
   id: string;
+  /**
+   * The question, shown as the FAQ entry heading.
+   */
   question: string;
+  /**
+   * The answer, supports rich formatting and links.
+   */
   answer: {
     root: {
       type: string;
@@ -257,7 +303,13 @@ export interface Faq {
     };
     [k: string]: unknown;
   };
+  /**
+   * Display order on the FAQ page. Lower numbers appear first.
+   */
   order?: number | null;
+  /**
+   * If unchecked, this FAQ is hidden from the public and visible only to admins.
+   */
   published: boolean;
   updatedAt: string;
   createdAt: string;

--- a/src/payload/collections/SocialSessions.ts
+++ b/src/payload/collections/SocialSessions.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload"
+import { socialSessionAvailability } from "../endpoints/socialSessionAvailability"
 
 // SocialSessions — registrable weekly club sessions with capacity, waitlist,
 // and member/non-member pricing. Registrations are made on-site through the
@@ -23,6 +24,13 @@ const statusOptions = [
 
 export const SocialSessions: CollectionConfig = {
   slug: "social-sessions",
+  endpoints: [
+    {
+      path: "/:id/availability",
+      method: "get",
+      handler: socialSessionAvailability,
+    },
+  ],
   admin: {
     useAsTitle: "title",
     defaultColumns: ["title", "date", "location", "maxCapacity", "status", "updatedAt"],

--- a/src/payload/endpoints/socialSessionAvailability.ts
+++ b/src/payload/endpoints/socialSessionAvailability.ts
@@ -1,0 +1,100 @@
+import type { PayloadHandler } from "payload"
+
+export const socialSessionAvailability: PayloadHandler = async (req) => {
+  const id = req.routeParams?.id as string | undefined
+
+  if (!id) {
+    return Response.json({ error: "Missing id" }, { status: 400 })
+  }
+
+  const session = await req.payload
+    .findByID({
+      collection: "social-sessions",
+      id,
+      req,
+    })
+    .catch(() => null)
+
+  if (!session) {
+    return Response.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const [registeredResult, waitlistedResult] = await Promise.all([
+    req.payload.count({
+      collection: "social-session-registrations",
+      where: {
+        and: [{ socialSession: { equals: id } }, { registrationStatus: { equals: "registered" } }],
+      },
+      req,
+    }),
+    req.payload.count({
+      collection: "social-session-registrations",
+      where: {
+        and: [{ socialSession: { equals: id } }, { registrationStatus: { equals: "waitlisted" } }],
+      },
+      req,
+    }),
+  ])
+
+  const registeredCount = registeredResult.totalDocs
+  const waitlistCount = waitlistedResult.totalDocs
+
+  const now = new Date()
+  let registrationOpen = true
+  let opensAt: string | null = null
+
+  if (session.registrationOpenAt) {
+    const openAt = new Date(session.registrationOpenAt)
+    if (openAt > now) {
+      registrationOpen = false
+      opensAt = openAt.toISOString()
+    }
+  }
+
+  if (registrationOpen && session.registrationCloseAt) {
+    const closeAt = new Date(session.registrationCloseAt)
+    if (closeAt < now) {
+      registrationOpen = false
+    }
+  }
+
+  let userStatus: "registered" | "waitlisted" | "not-registered" | null = null
+
+  if (req.user?.collection === "users") {
+    const userReg = await req.payload.find({
+      collection: "social-session-registrations",
+      where: {
+        and: [
+          { socialSession: { equals: id } },
+          { user: { equals: req.user.id } },
+          {
+            registrationStatus: {
+              in: ["registered", "waitlisted"],
+            },
+          },
+        ],
+      },
+      limit: 1,
+      req,
+    })
+
+    if (userReg.docs.length > 0) {
+      const status = userReg.docs[0].registrationStatus
+      userStatus = status === "registered" || status === "waitlisted" ? status : "not-registered"
+    } else {
+      userStatus = "not-registered"
+    }
+  }
+
+  return Response.json({
+    socialSessionId: id,
+    maxCapacity: session.maxCapacity,
+    registeredCount,
+    spotsLeft: Math.max(0, session.maxCapacity - registeredCount),
+    waitlistCapacity: session.waitlistCapacity,
+    waitlistCount,
+    registrationOpen,
+    opensAt,
+    userStatus,
+  })
+}


### PR DESCRIPTION
# Description

Adds a custom Payload endpoint at GET /api/social-sessions/:id/availability that returns capacity counts, registeration window state, and the authenticated user's registeration status for a givern social session.

Closes #14 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

Used Postman for testing the endpoint.

## **Test 1:**
**Unauthenticated Request**
Created a valid social session, and then copied the ID.
<img width="779" height="271" alt="image" src="https://github.com/user-attachments/assets/b6dc0028-ac20-4329-b7aa-a0929cb92c0e" />

Custom endpoint: http://localhost:3000/api/social-sessions/69f87454cabda39012e03b82/availability
<img width="1499" height="555" alt="image" src="https://github.com/user-attachments/assets/713d2d60-a31c-4a2a-8c5e-a6cc7b0f14b8" />
Expected 200 received. Since no authorization Header, userStatus: null as expected.

## **Test 2:**
**Invalid ID**
Custom endpoint: Invalid ID by setting it to http://localhost:3000/api/social-sessions/1/availability
<img width="1485" height="401" alt="image" src="https://github.com/user-attachments/assets/2fada81c-b6a5-499c-bb31-540246945ebf" />
Since an invalid ID was used, the expected 404 status returned.

## **Test 3**
**Authenticated Request**
Getting an auth token using Payload admin credentials (Credentials and token are hidden in the screenshot)
<img width="1495" height="580" alt="image" src="https://github.com/user-attachments/assets/d33ab47c-4658-4a75-97cf-ea809e920831" />

Expected status of 200, with userStatus as "not-registered" (since I didn't register with the account).
<img width="1488" height="917" alt="image" src="https://github.com/user-attachments/assets/00b6ccac-9225-439b-83e0-25f25aa184dd" />


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
