### PR TITLE
feat(payload): add beforeChangeHook for social session registration

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -149,6 +149,8 @@ export interface UserAuthOperations {
   };
 }
 /**
+ * Club executive accounts with full CMS access.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "admin".
  */
@@ -174,14 +176,28 @@ export interface Admin {
   collection: 'admin';
 }
 /**
+ * Club member accounts used for social session registration.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
   id: string;
+  /**
+   * Member's first name.
+   */
   firstName: string;
+  /**
+   * Member's last name.
+   */
   lastName: string;
+  /**
+   * University of Auckland UPI, if the member is a UoA student.
+   */
   upi?: string | null;
+  /**
+   * Contact phone number.
+   */
   phone?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -203,11 +219,16 @@ export interface User {
   collection: 'users';
 }
 /**
+ * Uploaded images referenced by events, social sessions, and executives.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
 export interface Media {
   id: string;
+  /**
+   * Alt text describing the image for screen readers and accessibility.
+   */
   alt: string;
   updatedAt: string;
   createdAt: string;
@@ -222,26 +243,51 @@ export interface Media {
   focalY?: number | null;
 }
 /**
+ * Club executive profiles shown on the public Executive Team page.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "executives".
  */
 export interface Executive {
   id: string;
+  /**
+   * Full name of the executive.
+   */
   name: string;
+  /**
+   * Role title, e.g. 'President', 'Treasurer', 'Social Coordinator'.
+   */
   role: string;
+  /**
+   * Short biography displayed on the executive's profile card.
+   */
   bio?: string | null;
+  /**
+   * Profile photo for the executive's card.
+   */
   photo?: (string | null) | Media;
+  /**
+   * Display order on the executive team page. Lower numbers appear first.
+   */
   order?: number | null;
   updatedAt: string;
   createdAt: string;
 }
 /**
+ * Frequently asked questions shown on the public FAQ page.
+ *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "faqs".
  */
 export interface Faq {
   id: string;
+  /**
+   * The question, shown as the FAQ entry heading.
+   */
   question: string;
+  /**
+   * The answer, supports rich formatting and links.
+   */
   answer: {
     root: {
       type: string;
@@ -257,7 +303,13 @@ export interface Faq {
     };
     [k: string]: unknown;
   };
+  /**
+   * Display order on the FAQ page. Lower numbers appear first.
+   */
   order?: number | null;
+  /**
+   * If unchecked, this FAQ is hidden from the public and visible only to admins.
+   */
   published: boolean;
   updatedAt: string;
   createdAt: string;

--- a/src/payload/collections/SocialSessionRegistrations.ts
+++ b/src/payload/collections/SocialSessionRegistrations.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload"
+import { checkCapacity } from "../hooks/socialSessionRegistrations/checkCapacity"
 
 // SocialSessionRegistrations — on-site registrations for a social session.
 // Members register via their authenticated account; guests register with a
@@ -50,6 +51,7 @@ export const SocialSessionRegistrations: CollectionConfig = {
 
         return data
       },
+      checkCapacity,
     ],
   },
   fields: [

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -5,7 +5,8 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
   if (operation !== "create") {
     return data
   }
-  const sessionID = data.socialSession
+  const sessionID =
+    typeof data.socialSession === "string" ? data.socialSession : data.socialSession?.id
   if (!sessionID) {
     throw new APIError("socialSession is required", 400)
   }

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -1,0 +1,69 @@
+import type { CollectionBeforeChangeHook, Where } from "payload"
+
+export const beforeChangeHook: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
+  if (operation !== "create") {
+    return data
+  }
+  const sessionID = data.socialSession
+  const session = await req.payload.findByID({
+    collection: "social-sessions",
+    id: sessionID,
+  })
+  if (!session) {
+    throw new Error("Social session not found")
+  }
+  if (session.status === "completed" || session.status === "cancelled") {
+    throw new Error("This social session is no longer accepting registrations")
+  }
+  const whereUser: Where = data.user
+    ? { user: { equals: data.user } }
+    : { guestEmail: { equals: data.guestEmail } }
+  const alreadyRegistered = await req.payload.count({
+    collection: "social-session-registrations",
+    where: {
+      and: [
+        {
+          socialSession: { equals: sessionID },
+        },
+        whereUser,
+      ],
+    },
+  })
+  if (alreadyRegistered.totalDocs !== 0) {
+    throw new Error("You are already registered for this social session")
+  }
+  const registeredCount = await req.payload.count({
+    collection: "social-session-registrations",
+    where: {
+      and: [
+        {
+          socialSession: { equals: sessionID },
+        },
+        {
+          registrationStatus: { equals: "registered" },
+        },
+      ],
+    },
+  })
+  const waitlistCount = await req.payload.count({
+    collection: "social-session-registrations",
+    where: {
+      and: [
+        {
+          socialSession: { equals: sessionID },
+        },
+        {
+          registrationStatus: { equals: "waitlisted" },
+        },
+      ],
+    },
+  })
+  if (registeredCount.totalDocs < session.maxCapacity) {
+    data.registrationStatus = "registered"
+  } else if (waitlistCount.totalDocs < session.waitlistCapacity) {
+    data.registrationStatus = "waitlisted"
+  } else {
+    throw new Error("This social session is full and its waitlist is full")
+  }
+  return data
+}

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -1,4 +1,6 @@
 import type { CollectionBeforeChangeHook, Where } from "payload"
+import { APIError } from "payload"
+import { sendRegistrationConfirmation } from "@/lib/email/registrationConfimration.ts"
 
 export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
   if (operation !== "create") {
@@ -6,20 +8,20 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
   }
   const sessionID = data.socialSession
   if (!sessionID) {
-    throw new Error("Social session not found")
+    throw new APIError("socialSession is required", 400)
   }
   const session = await req.payload.findByID({
     collection: "social-sessions",
     id: sessionID,
   })
   if (!session) {
-    throw new Error("Social session not found")
+    throw new APIError("Social session not found", 404)
   }
   if (session.status === "completed" || session.status === "cancelled") {
-    throw new Error("This social session is no longer accepting registrations")
+    throw new APIError("This social session is no longer accepting registrations", 400)
   }
   if (!data.user && !data.guestEmail) {
-    throw new Error("Registration must include a user or guest email")
+    throw new APIError("Registration must include a user or guest email", 400)
   }
   const whereUser: Where = data.user
     ? { user: { equals: data.user } }
@@ -35,7 +37,7 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
     },
   })
   if (alreadyRegistered.totalDocs !== 0) {
-    throw new Error("You are already registered for this social session")
+    throw new APIError("You are already registered for this social session", 409)
   }
   const registeredCount = await req.payload.count({
     collection: "social-session-registrations",
@@ -68,7 +70,14 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
   } else if (waitlistCount.totalDocs < session.waitlistCapacity) {
     data.registrationStatus = "waitlisted"
   } else {
-    throw new Error("This social session and its waitlist are full")
+    throw new APIError("This social session and its waitlist are full", 409)
   }
+  await sendRegistrationConfirmation({
+    session,
+    recipient: data.user
+      ? { type: "user", id: data.user }
+      : { type: "guest", email: data.guestEmail, name: data.guestName },
+    status: data.registrationStatus,
+  })
   return data
 }

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -1,10 +1,13 @@
 import type { CollectionBeforeChangeHook, Where } from "payload"
 
-export const beforeChangeHook: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
+export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
   if (operation !== "create") {
     return data
   }
   const sessionID = data.socialSession
+  if (!sessionID) {
+    throw new Error("Social session not found")
+  }
   const session = await req.payload.findByID({
     collection: "social-sessions",
     id: sessionID,
@@ -15,6 +18,9 @@ export const beforeChangeHook: CollectionBeforeChangeHook = async ({ data, opera
   if (session.status === "completed" || session.status === "cancelled") {
     throw new Error("This social session is no longer accepting registrations")
   }
+  if (!data.user && !data.guestEmail) {
+    throw new Error("Registration must include a user or guest email")
+  }
   const whereUser: Where = data.user
     ? { user: { equals: data.user } }
     : { guestEmail: { equals: data.guestEmail } }
@@ -22,9 +28,8 @@ export const beforeChangeHook: CollectionBeforeChangeHook = async ({ data, opera
     collection: "social-session-registrations",
     where: {
       and: [
-        {
-          socialSession: { equals: sessionID },
-        },
+        { socialSession: { equals: sessionID } },
+        { registrationStatus: { not_equals: "cancelled" } },
         whereUser,
       ],
     },
@@ -63,7 +68,7 @@ export const beforeChangeHook: CollectionBeforeChangeHook = async ({ data, opera
   } else if (waitlistCount.totalDocs < session.waitlistCapacity) {
     data.registrationStatus = "waitlisted"
   } else {
-    throw new Error("This social session is full and its waitlist is full")
+    throw new Error("This social session and its waitlist are full")
   }
   return data
 }

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -1,6 +1,5 @@
 import type { CollectionBeforeChangeHook, Where } from "payload"
 import { APIError } from "payload"
-import { sendRegistrationConfirmation } from "@/lib/email/registrationConfimration.ts"
 
 export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
   if (operation !== "create") {
@@ -72,12 +71,5 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
   } else {
     throw new APIError("This social session and its waitlist are full", 409)
   }
-  await sendRegistrationConfirmation({
-    session,
-    recipient: data.user
-      ? { type: "user", id: data.user }
-      : { type: "guest", email: data.guestEmail, name: data.guestName },
-    status: data.registrationStatus,
-  })
   return data
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

Added a before change hook for registration, that checks the current capacity of the social session 
Closes #12 <!-- Remove if not linked to an issue -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

### Test 1 - No longer accepting registrations
The error of the social session no longer accepting registrations was tested by creating a new social session with the status completed, and then trying to create a registration for that social session. Then the social session was updated to have the status cancelled, and the registration was tested again. Both times, the error was correctly thrown.

<img width="767" height="145" alt="cancelled_completed" src="https://github.com/user-attachments/assets/64574a44-8d06-4df4-97a7-5d8ebd7fbd85" />

### Test 2 - Already registered users
The error for the user already being registered for the social session was tested by creating a registration with a user for a social session, and then trying to create another registration for the same social session with the same user. This correctly threw the error. Using the user over the guest email if it was provided was also tested, by making a registration with the same user but with a different guest email, and this still threw the error correctly. The guest email was also tested, creating a registration with no user and just a guest email, and then creating the same registration with the same guest email. This again, threw the correct error.

<img width="656" height="137" alt="already_registered" src="https://github.com/user-attachments/assets/fd952dab-aca6-40f8-a9b7-ebd011e0566e" />

### Test 3 - Waitlist users
The setting the user to waitlist automatically was tested by creating a new registration for a social session which the capacity was already full, but the waitlist wasn't. This correctly set the user's registration to waitlisted. 

<img width="328" height="626" alt="waitlisted1" src="https://github.com/user-attachments/assets/2ca8f5a8-6317-4562-bf45-771ad90b8e04" />
<img width="841" height="77" alt="waitlisted2" src="https://github.com/user-attachments/assets/1277a428-1aa6-426c-8a08-36ebbfa7e9c3" />

### Test 4 - Max capacity
The error for the social session being full was tested by creating a social session which the capacity and the waitlist capacity were already full, and trying to create a registration for that social session. Correctly throws the social session full error.

<img width="675" height="145" alt="full_session" src="https://github.com/user-attachments/assets/c0563652-09aa-4889-bdf9-666b27739fb2" />

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
