### PR TITLE
feat(payload): wire in registration confirmation email

### DIFF
--- a/src/lib/email/registrationConfirmation.ts
+++ b/src/lib/email/registrationConfirmation.ts
@@ -7,16 +7,26 @@ interface RegistrationConfirmationEmailProps {
   sessionDate: string
   sessionTime: string
   sessionLocation: string
+  isWaitlisted: boolean
 }
 
 const sendRegistrationConfirmation = async (props: RegistrationConfirmationEmailProps) => {
   const payload = await getPayload({ config: await config })
-  const emailContent = `Hello,\n\nThank you for registering for ${props.sessionTitle}.\n\n The session is on ${props.sessionDate} at ${props.sessionTime} at ${props.sessionLocation}.\n\n Kind Regards,\n UOAVC Team`
+
+  const subject = props.isWaitlisted
+    ? `You're on the waitlist for ${props.sessionTitle}`
+    : `You're registered for ${props.sessionTitle}!`
+
+  const intro = props.isWaitlisted
+    ? `Hello,\n\nYou've been added to the waitlist for ${props.sessionTitle}. We'll notify you if a spot opens up.`
+    : `Hello,\n\nThank you for registering for ${props.sessionTitle}.`
+
+  const emailContent = `${intro}\n\nThe session is on ${props.sessionDate} at ${props.sessionTime} at ${props.sessionLocation}.\n\nKind Regards,\nUOAVC Team`
 
   try {
     await payload.sendEmail({
       to: props.to,
-      subject: `You're registered for ${props.sessionTitle}!`,
+      subject,
       text: emailContent,
     })
   } catch (error) {

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -1,5 +1,6 @@
 import type { CollectionBeforeChangeHook, Where } from "payload"
 import { APIError } from "payload"
+import sendRegistrationConfirmation from "@/lib/email/registrationConfirmation"
 
 export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
   if (operation !== "create") {
@@ -72,5 +73,34 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
   } else {
     throw new APIError("This social session and its waitlist are full", 409)
   }
+
+  let recipientEmail: string | undefined
+  if (data.user) {
+    const userID = typeof data.user === "string" ? data.user : data.user.id
+    try {
+      const user = await req.payload.findByID({ collection: "users", id: userID })
+      recipientEmail = user.email
+    } catch {
+      recipientEmail = undefined
+    }
+  } else if (data.guestEmail) {
+    recipientEmail = data.guestEmail
+  }
+
+  if (recipientEmail) {
+    await sendRegistrationConfirmation({
+      to: recipientEmail,
+      sessionTitle: session.title,
+      sessionDate: new Date(session.date).toLocaleDateString("en-NZ", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }),
+      sessionTime: `${session.startTime} - ${session.endTime}`,
+      sessionLocation: session.location,
+      isWaitlisted: data.registrationStatus === "waitlisted",
+    })
+  }
+
   return data
 }


### PR DESCRIPTION
# Description

This PR wires the previously-unused `sendRegistrationConfirmation` helper into the `checkCapacity` `beforeChange` hook so that a confirmation email is sent whenever a `socialSessionRegistrations` row is successfully created. It also extends the email template to differentiate between confirmed and waitlisted registrations.

- imports `sendRegistrationConfirmation` into `src/payload/hooks/socialSessionRegistrations/checkCapacity.ts` and calls it after capacity validation passes
- resolves the recipient email by looking up the linked user via `req.payload.findByID({ collection: "users", ... })` when `data.user` is set, and falling back to `data.guestEmail` for guest registrations
- formats `session.date` with `toLocaleDateString("en-NZ", ...)` and combines `session.startTime`/`session.endTime` for the email payload
- passes `isWaitlisted: data.registrationStatus === "waitlisted"` so the email reflects the actual outcome of capacity checks
- updates `RegistrationConfirmationEmailProps` in `src/lib/email/registrationConfirmation.ts` to require `isWaitlisted`, and branches the `subject` and intro copy between the registered and waitlisted paths
- swallows user-lookup failures by leaving `recipientEmail` undefined so a missing user record does not block the registration write

Note that the email send is awaited inside the `beforeChange` hook, so an email transport failure will surface as an error from the hook. The capacity logic from #12 still runs before this block, so the email is only sent once a registration is confirmed to be either `registered` or `waitlisted`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

To verify locally:

1. Ensure Payload's email transport is configured (or watch the dev console for the rendered email).
2. Create a `socialSessions` document with a small `capacity` and a `waitlistCapacity` so both branches are reachable.
3. Trigger a registration as a logged-in user (omit `guestEmail`, set `user`) and confirm an email addressed to `req.user`'s email arrives with the subject `You're registered for <title>!`.
4. Trigger a registration as a guest (omit `user`, set `guestEmail`) and confirm the email is sent to `data.guestEmail`.
5. Fill the session past `capacity` so the next registration is assigned `registrationStatus: "waitlisted"` and confirm the email subject becomes `You're on the waitlist for <title>` with the waitlist intro copy.
6. Fill the waitlist as well and confirm the hook still throws `This social session and its waitlist are full` with no email sent.

I would recommend testing both the user and guest paths in the same session to confirm the recipient resolution branches independently.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member