### PR TITLE
Feat/64 social session checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,4 @@ DATABASE_URI=mongodb://127.0.0.1/your-database-name
 RESEND_API_KEY=resend-api-key
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...
-STRIPE_SUCCESS_URL=http://localhost:3000/sessions/success
-STRIPE_CANCEL_URL=http://localhost:3000/sessions/cancel
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ Copy the example file:
 cp .env.example .env
 ```
 
-After doing this you can edit each variable in the `.env` file with the appropriate values.
+Then fill in each variable in `.env`:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `PAYLOAD_SECRET` | Yes | Secret used by Payload to sign auth tokens. Any long random string. |
+| `DATABASE_URI` | Yes | MongoDB connection string (local or remote). |
+| `RESEND_API_KEY` | Yes | API key for [Resend](https://resend.com), used to send transactional emails (e.g. registration confirmations). |
+| `STRIPE_SECRET_KEY` | Yes | Stripe secret key (use a `sk_test_...` key in development). Required by the social session checkout endpoint. |
+| `STRIPE_WEBHOOK_SECRET` | Yes | Stripe webhook signing secret (`whsec_...`), used to verify incoming payment events. |
+| `NEXT_PUBLIC_SITE_URL` | Yes | Public base URL of the site (e.g. `http://localhost:3000` in development). Used to build Stripe Checkout `success_url` / `cancel_url`. |
 
 ### Scripts
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -496,6 +496,10 @@ export interface SocialSessionRegistration {
    * Payment state for paid social sessions.
    */
   paymentStatus?: ('pending' | 'paid' | 'free') | null;
+  /**
+   * Stripe Checkout Session ID used to reconcile webhook events to this registration.
+   */
+  stripeCheckoutSessionId?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -750,6 +754,7 @@ export interface SocialSessionRegistrationsSelect<T extends boolean = true> {
   registeredAt?: T;
   amountPaid?: T;
   paymentStatus?: T;
+  stripeCheckoutSessionId?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload/collections/SocialSessionRegistrations.ts
+++ b/src/payload/collections/SocialSessionRegistrations.ts
@@ -146,5 +146,19 @@ export const SocialSessionRegistrations: CollectionConfig = {
       },
       admin: { description: "Payment state for paid social sessions." },
     },
+    {
+      name: "stripeCheckoutSessionId",
+      type: "text",
+      required: false,
+      access: {
+        read: ({ req }) => req.user?.collection === "admin",
+        update: ({ req }) => req.user?.collection === "admin",
+      },
+      admin: {
+        description:
+          "Stripe Checkout Session ID used to reconcile webhook events to this registration.",
+        readOnly: true,
+      },
+    },
   ],
 }

--- a/src/payload/collections/SocialSessions.ts
+++ b/src/payload/collections/SocialSessions.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from "payload"
 import { socialSessionAvailability } from "../endpoints/socialSessionAvailability"
+import { socialSessionCheckout } from "../endpoints/socialSessionCheckout"
 
 // SocialSessions — registrable weekly club sessions with capacity, waitlist,
 // and member/non-member pricing. Registrations are made on-site through the
@@ -29,6 +30,11 @@ export const SocialSessions: CollectionConfig = {
       path: "/:id/availability",
       method: "get",
       handler: socialSessionAvailability,
+    },
+    {
+      path: "/:id/checkout",
+      method: "post",
+      handler: socialSessionCheckout,
     },
   ],
   admin: {

--- a/src/payload/endpoints/socialSessionCheckout.ts
+++ b/src/payload/endpoints/socialSessionCheckout.ts
@@ -1,0 +1,149 @@
+import type { PayloadHandler } from "payload"
+import { APIError, addDataAndFileToRequest } from "payload"
+import { stripe } from "@/lib/stripe"
+import { resolveRegistrationStatus } from "../hooks/socialSessionRegistrations/resolveRegistrationStatus"
+
+// POST /api/social-sessions/:id/checkout
+//
+// Turns a registration intent for a *paid* social session into a Stripe
+// Checkout Session. It pre-flights capacity (sharing resolveRegistrationStatus
+// with the beforeChange hook), creates a pending registration to hold the spot,
+// then hands back a redirect URL. Free sessions are rejected — those go through
+// the direct create path on social-session-registrations. Payment success is
+// reconciled later by the Stripe webhook (Ticket 2) via metadata.registrationId
+// and the stored stripeCheckoutSessionId.
+export const socialSessionCheckout: PayloadHandler = async (req) => {
+  const id = req.routeParams?.id as string | undefined
+  if (!id) {
+    return Response.json({ error: "Missing id" }, { status: 400 })
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
+  if (!siteUrl) {
+    return Response.json(
+      { error: "Server misconfigured: NEXT_PUBLIC_SITE_URL is not set" },
+      { status: 500 },
+    )
+  }
+
+  await addDataAndFileToRequest(req)
+  const body = (req.data ?? {}) as { guestName?: string; guestEmail?: string }
+
+  const isMember = req.user?.collection === "users"
+  const userId = isMember ? req.user?.id : undefined
+  const guestName = body.guestName?.trim() || undefined
+  const guestEmail = body.guestEmail?.trim() || undefined
+
+  if (!isMember && (!guestName || !guestEmail)) {
+    return Response.json(
+      { error: "guestName and guestEmail are required for guest checkout" },
+      { status: 400 },
+    )
+  }
+
+  // Pre-flight: load the session and decide registered vs waitlisted. Throws an
+  // APIError for closed sessions, duplicate sign-ups, or a full waitlist.
+  let session: Awaited<ReturnType<typeof resolveRegistrationStatus>>["session"]
+  let registrationStatus: "registered" | "waitlisted"
+  try {
+    const result = await resolveRegistrationStatus({
+      req,
+      sessionID: id,
+      user: userId,
+      guestEmail: isMember ? undefined : guestEmail,
+    })
+    session = result.session
+    registrationStatus = result.registrationStatus
+  } catch (err) {
+    if (err instanceof APIError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
+  }
+
+  // Resolve price. Members pay memberPrice, everyone else nonMemberPrice. A
+  // null/0 price means the session is free — reject so it uses the direct path.
+  const price = isMember ? session.memberPrice : session.nonMemberPrice
+  if (!price || price <= 0) {
+    return Response.json(
+      { error: "This session is free — register directly without checkout." },
+      { status: 400 },
+    )
+  }
+
+  const customerEmail = isMember ? req.user?.email : guestEmail
+
+  // Hold the spot with a pending registration. skipConfirmationEmail stops the
+  // capacity hook from emailing now — that fires on payment success instead.
+  let registration: { id: string | number }
+  try {
+    registration = await req.payload.create({
+      collection: "social-session-registrations",
+      data: {
+        socialSession: id,
+        user: userId,
+        guestName: isMember ? undefined : guestName,
+        guestEmail: isMember ? undefined : guestEmail,
+        registrationStatus,
+        registeredAt: new Date().toISOString(),
+        paymentStatus: "pending",
+        amountPaid: price,
+      },
+      req,
+      context: { skipConfirmationEmail: true },
+    })
+  } catch (err) {
+    if (err instanceof APIError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
+  }
+
+  // Create the hosted Stripe Checkout Session. If this throws after the
+  // registration exists, delete it so it doesn't leak and occupy capacity.
+  try {
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "payment",
+      customer_email: customerEmail ?? undefined,
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: "nzd",
+            unit_amount: Math.round(price * 100),
+            product_data: { name: session.title },
+          },
+        },
+      ],
+      metadata: {
+        registrationId: String(registration.id),
+        socialSessionId: id,
+      },
+      // Auto-expire abandoned checkouts (Stripe max is 24h from now).
+      expires_at: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+      // TODO: confirm these frontend routes once the checkout result pages exist.
+      success_url: `${siteUrl}/social-sessions/${id}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${siteUrl}/social-sessions/${id}/checkout/cancelled`,
+    })
+
+    // Store the session id so the webhook can match events back to this row
+    // without relying solely on Stripe metadata.
+    await req.payload.update({
+      collection: "social-session-registrations",
+      id: registration.id,
+      data: { stripeCheckoutSessionId: checkoutSession.id },
+      req,
+    })
+
+    return Response.json({ url: checkoutSession.url, registrationId: registration.id })
+  } catch (err) {
+    await req.payload
+      .delete({ collection: "social-session-registrations", id: registration.id, req })
+      .catch(() => {})
+
+    if (err instanceof APIError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    return Response.json({ error: "Failed to create checkout session" }, { status: 502 })
+  }
+}

--- a/src/payload/endpoints/socialSessionCheckout.ts
+++ b/src/payload/endpoints/socialSessionCheckout.ts
@@ -71,6 +71,14 @@ export const socialSessionCheckout: PayloadHandler = async (req) => {
     )
   }
 
+  // We can't refund yet, so don't take money for a waitlist spot
+  if (registrationStatus === "waitlisted") {
+    return Response.json(
+      { error: "This session is full, you can join the waitlist without payment." },
+      { status: 409 },
+    )
+  }
+
   const customerEmail = isMember ? req.user?.email : guestEmail
 
   // Hold the spot with a pending registration. skipConfirmationEmail stops the

--- a/src/payload/endpoints/socialSessionCheckout.ts
+++ b/src/payload/endpoints/socialSessionCheckout.ts
@@ -87,7 +87,7 @@ export const socialSessionCheckout: PayloadHandler = async (req) => {
         registrationStatus,
         registeredAt: new Date().toISOString(),
         paymentStatus: "pending",
-        amountPaid: price,
+        // amountPaid stays null until payment succeeds (set by webhook #75)
       },
       req,
       context: { skipConfirmationEmail: true },

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -3,7 +3,12 @@ import { APIError } from "payload"
 import sendRegistrationConfirmation from "@/lib/email/registrationConfirmation"
 import { resolveRegistrationStatus } from "./resolveRegistrationStatus"
 
-export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
+export const checkCapacity: CollectionBeforeChangeHook = async ({
+  data,
+  operation,
+  req,
+  context,
+}) => {
   if (operation !== "create") {
     return data
   }
@@ -20,6 +25,13 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
     guestEmail: data.guestEmail,
   })
   data.registrationStatus = registrationStatus
+
+  // Paid registrations are created in a "pending" state by the Stripe checkout
+  // endpoint; their confirmation email fires on payment success instead, so the
+  // endpoint sets this flag to suppress the email here.
+  if (context?.skipConfirmationEmail) {
+    return data
+  }
 
   let recipientEmail: string | undefined
   if (data.user) {

--- a/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
+++ b/src/payload/hooks/socialSessionRegistrations/checkCapacity.ts
@@ -1,6 +1,7 @@
-import type { CollectionBeforeChangeHook, Where } from "payload"
+import type { CollectionBeforeChangeHook } from "payload"
 import { APIError } from "payload"
 import sendRegistrationConfirmation from "@/lib/email/registrationConfirmation"
+import { resolveRegistrationStatus } from "./resolveRegistrationStatus"
 
 export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operation, req }) => {
   if (operation !== "create") {
@@ -11,68 +12,14 @@ export const checkCapacity: CollectionBeforeChangeHook = async ({ data, operatio
   if (!sessionID) {
     throw new APIError("socialSession is required", 400)
   }
-  const session = await req.payload.findByID({
-    collection: "social-sessions",
-    id: sessionID,
+
+  const { session, registrationStatus } = await resolveRegistrationStatus({
+    req,
+    sessionID,
+    user: typeof data.user === "string" ? data.user : data.user?.id,
+    guestEmail: data.guestEmail,
   })
-  if (!session) {
-    throw new APIError("Social session not found", 404)
-  }
-  if (session.status === "completed" || session.status === "cancelled") {
-    throw new APIError("This social session is no longer accepting registrations", 400)
-  }
-  if (!data.user && !data.guestEmail) {
-    throw new APIError("Registration must include a user or guest email", 400)
-  }
-  const whereUser: Where = data.user
-    ? { user: { equals: data.user } }
-    : { guestEmail: { equals: data.guestEmail } }
-  const alreadyRegistered = await req.payload.count({
-    collection: "social-session-registrations",
-    where: {
-      and: [
-        { socialSession: { equals: sessionID } },
-        { registrationStatus: { not_equals: "cancelled" } },
-        whereUser,
-      ],
-    },
-  })
-  if (alreadyRegistered.totalDocs !== 0) {
-    throw new APIError("You are already registered for this social session", 409)
-  }
-  const registeredCount = await req.payload.count({
-    collection: "social-session-registrations",
-    where: {
-      and: [
-        {
-          socialSession: { equals: sessionID },
-        },
-        {
-          registrationStatus: { equals: "registered" },
-        },
-      ],
-    },
-  })
-  const waitlistCount = await req.payload.count({
-    collection: "social-session-registrations",
-    where: {
-      and: [
-        {
-          socialSession: { equals: sessionID },
-        },
-        {
-          registrationStatus: { equals: "waitlisted" },
-        },
-      ],
-    },
-  })
-  if (registeredCount.totalDocs < session.maxCapacity) {
-    data.registrationStatus = "registered"
-  } else if (waitlistCount.totalDocs < session.waitlistCapacity) {
-    data.registrationStatus = "waitlisted"
-  } else {
-    throw new APIError("This social session and its waitlist are full", 409)
-  }
+  data.registrationStatus = registrationStatus
 
   let recipientEmail: string | undefined
   if (data.user) {

--- a/src/payload/hooks/socialSessionRegistrations/resolveRegistrationStatus.ts
+++ b/src/payload/hooks/socialSessionRegistrations/resolveRegistrationStatus.ts
@@ -1,0 +1,89 @@
+import type { PayloadRequest, Where } from "payload"
+import { APIError } from "payload"
+import type { SocialSession } from "@/payload-types"
+
+interface ResolveRegistrationStatusArgs {
+  req: PayloadRequest
+  sessionID: string
+  /** Authenticated member ID, if any. */
+  user?: string | null
+  /** Guest contact email, for non-member registrations. */
+  guestEmail?: string | null
+}
+
+interface ResolveRegistrationStatusResult {
+  session: SocialSession
+  registrationStatus: "registered" | "waitlisted"
+}
+
+// Shared pre-flight for social session registrations. Loads the parent session,
+// rejects closed sessions and duplicate sign-ups, and decides whether the next
+// registration is confirmed or waitlisted. Both the beforeChange hook and the
+// Stripe checkout endpoint call this so capacity rules stay in one place - we do
+// not want to take payment for a session the hook would then reject.
+export async function resolveRegistrationStatus({
+  req,
+  sessionID,
+  user,
+  guestEmail,
+}: ResolveRegistrationStatusArgs): Promise<ResolveRegistrationStatusResult> {
+  const session = await req.payload.findByID({
+    collection: "social-sessions",
+    id: sessionID,
+  })
+  if (!session) {
+    throw new APIError("Social session not found", 404)
+  }
+  if (session.status === "completed" || session.status === "cancelled") {
+    throw new APIError("This social session is no longer accepting registrations", 400)
+  }
+  if (!user && !guestEmail) {
+    throw new APIError("Registration must include a user or guest email", 400)
+  }
+
+  const whereUser: Where = user
+    ? { user: { equals: user } }
+    : { guestEmail: { equals: guestEmail } }
+  const alreadyRegistered = await req.payload.count({
+    collection: "social-session-registrations",
+    where: {
+      and: [
+        { socialSession: { equals: sessionID } },
+        { registrationStatus: { not_equals: "cancelled" } },
+        whereUser,
+      ],
+    },
+  })
+  if (alreadyRegistered.totalDocs !== 0) {
+    throw new APIError("You are already registered for this social session", 409)
+  }
+
+  const [registeredCount, waitlistCount] = await Promise.all([
+    req.payload.count({
+      collection: "social-session-registrations",
+      where: {
+        and: [
+          { socialSession: { equals: sessionID } },
+          { registrationStatus: { equals: "registered" } },
+        ],
+      },
+    }),
+    req.payload.count({
+      collection: "social-session-registrations",
+      where: {
+        and: [
+          { socialSession: { equals: sessionID } },
+          { registrationStatus: { equals: "waitlisted" } },
+        ],
+      },
+    }),
+  ])
+
+  if (registeredCount.totalDocs < session.maxCapacity) {
+    return { session, registrationStatus: "registered" }
+  }
+  if (waitlistCount.totalDocs < session.waitlistCapacity) {
+    return { session, registrationStatus: "waitlisted" }
+  }
+  throw new APIError("This social session and its waitlist are full", 409)
+}


### PR DESCRIPTION
# Description

Adds `POST /api/social-sessions/:id/checkout`, creates a pending registration + Stripe Checkout Session for paid social sessions. Cleans up the pending row if Stripe fails. Adds `stripeCheckoutSessionId` to `SocialSessionRegistrations`.

Closes #64  <!-- Remove if not linked to an issue -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

Tested manually, see breakdown below.

**Setup:**
- Stripe test key in `.env`
- Existing paid social session (`monday social session`, memberPrice 14, nonMemberPrice 3)

### Test 1: Happy path (guest checkout)

```bash
curl -X POST http://localhost:3000/api/social-sessions/69fef1c4e93c220e9c10e060/checkout \
  -H "Content-Type: application/json" \
  -d '{"guestName":"Test Guest","guestEmail":"guest@example.com"}'
```

Response: `{ url, registrationId: 6a1ce3547bf243fea37ba4e4 }`

Stripe Checkout rendered with NZ$3.00 (non-member price) + `guest@example.com` pre-filled:

<img width="1110" height="731" alt="image" src="https://github.com/user-attachments/assets/169c1af2-3b93-4792-87c1-1adf5669acdc" />

Payload row created with `paymentStatus: pending`, `amountPaid: 3`, `stripeCheckoutSessionId` populated:

<img width="2012" height="1273" alt="image" src="https://github.com/user-attachments/assets/2fb1c470-9b7a-4d51-969c-9b99b2a81493" />

### Test 2: Free session rejected

Created a free session (no memberPrice / nonMemberPrice), then ran:

```bash
curl -X POST http://localhost:3000/api/social-sessions/6a1ce9397bf243fea37ba5c9/checkout \
  -H "Content-Type: application/json" \
  -d '{"guestName":"Test Guest","guestEmail":"guest@example.com"}'
```

Response: `{"error":"This session is free — register directly without checkout."}`

<img width="593" height="56" alt="image" src="https://github.com/user-attachments/assets/5243ad7c-58cc-4094-b2ba-c0dd99aacab1" />

No new registration row created (4 rows, all for `monday social session`):

<img width="1982" height="555" alt="image" src="https://github.com/user-attachments/assets/bbd6de0f-87a9-49ce-9f11-77aed29b1056" />

### Test 3: Stripe failure cleans up

Temporarily set `STRIPE_SECRET_KEY=sk_test_bogus` in `.env`, restarted dev, then ran:

```bash
curl -X POST http://localhost:3000/api/social-sessions/69fef1c4e93c220e9c10e060/checkout \
  -H "Content-Type: application/json" \
  -d '{"guestName":"Test Guest 2","guestEmail":"guest2@example.com"}'
```

Response: `{"error":"Failed to create checkout session"}`

<img width="582" height="57" alt="image" src="https://github.com/user-attachments/assets/ba838122-c67d-4810-a126-ad85e8247654" />

No leftover pending row for `Test Guest 2`, cleanup logic deleted it after Stripe failed:

<img width="1977" height="520" alt="image" src="https://github.com/user-attachments/assets/3e692dff-ad63-4815-b65f-318d4bba9da4" />


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
