### PR TITLE
fix(stripe): construct client lazily so builds don't require the key

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,10 +1,31 @@
 import Stripe from "stripe"
 
-if (!process.env.STRIPE_SECRET_KEY && process.env.NODE_ENV === "production") {
-  throw new Error("STRIPE_SECRET_KEY is required in production")
+let client: Stripe | null = null
+
+// Lazily construct the Stripe client on first use. The key is only required at
+// runtime when we actually talk to Stripe — not when the module is imported.
+// `next build` imports every route while collecting page data, so constructing
+// (or throwing) at import time would fail the build in any environment without
+// STRIPE_SECRET_KEY (e.g. CI), even though the build never calls Stripe.
+function getClient(): Stripe {
+  if (!client) {
+    const key = process.env.STRIPE_SECRET_KEY
+    if (!key) {
+      throw new Error("STRIPE_SECRET_KEY is required")
+    }
+    client = new Stripe(key, {
+      apiVersion: "2026-04-22.dahlia",
+      typescript: true,
+    })
+  }
+  return client
 }
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "", {
-  apiVersion: "2026-04-22.dahlia",
-  typescript: true,
+// Preserve the `stripe.foo.bar(...)` API while deferring construction to the
+// first property access, so importing this module has no side effects.
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    const c = getClient()
+    return Reflect.get(c, prop, c)
+  },
 })


### PR DESCRIPTION
# Description

`src/lib/stripe.ts` constructed the Stripe client — and threw when `STRIPE_SECRET_KEY` was unset in production — at **module load**. `next build` imports every route while collecting page data, so any built route that imports this module evaluates it at build time and fails the build in environments without the key (e.g. CI, which only provides `PAYLOAD_SECRET` / `DATABASE_URI`). The build never actually calls Stripe.

This defers construction (and the key check) to first use via a `Proxy`, keeping the exact `import { stripe }` API. Importing the module is now side-effect-free, so `next build` no longer needs a Stripe key. The key is still required at runtime the moment Stripe is actually used.

Unblocks the CI build on #75 and #76, which are the first PRs to import `@/lib/stripe` into a built route.

Closes # (issue) <!-- no linked issue -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Biome clean (`biome check src/lib/stripe.ts` — no warnings)
- [x] CI `Build Application` on this PR (was the failing check on #75/#76)

Note: prod runtime still requires `STRIPE_SECRET_KEY` to be set (Fly secret) before Stripe is used — this PR only stops the key being required to *build*.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
