### PR TITLE
Feat/56 toggle pill group

### DIFF
--- a/src/components/TogglePillGroup/TogglePillGroup.tsx
+++ b/src/components/TogglePillGroup/TogglePillGroup.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { cn } from "@/lib/utils"
+
+export type TogglePillOption = {
+  label: string
+  value: string
+}
+
+type TogglePillGroupProps = {
+  options: readonly [TogglePillOption, TogglePillOption]
+  value: string
+  onChange: (value: string) => void
+  "aria-label": string
+  className?: string
+}
+
+const pillItemClasses = cn(
+  "h-auto rounded-full border-2 px-6 py-2 font-heading font-normal text-[2.75rem] uppercase leading-none",
+  "transition-colors duration-200",
+  "border-brand-primary bg-transparent text-brand-primary",
+  "hover:bg-brand-yellow hover:text-brand-primary data-[state=off]:hover:border-brand-yellow data-[state=off]:hover:text-brand-light-grey",
+  "aria-pressed:bg-brand-yellow data-[state=on]:bg-brand-yellow data-[state=on]:border-brand-yellow",
+)
+
+export function TogglePillGroup({
+  options,
+  value,
+  onChange,
+  "aria-label": ariaLabel,
+  className,
+}: TogglePillGroupProps) {
+  return (
+    <ToggleGroup
+      aria-label={ariaLabel}
+      className={cn("gap-8", className)}
+      onValueChange={(next) => {
+        // Radix emits "" when the selected item is clicked again; ignore it so
+        // one option is always selected.
+        if (next) onChange(next)
+      }}
+      type="single"
+      value={value}
+    >
+      {options.map((option) => (
+        <ToggleGroupItem className={pillItemClasses} key={option.value} value={option.value}>
+          {option.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}

--- a/src/components/TogglePillGroup/TogglePillGroup.tsx
+++ b/src/components/TogglePillGroup/TogglePillGroup.tsx
@@ -20,7 +20,13 @@ const pillItemClasses = cn(
   "h-auto rounded-full border-2 px-6 py-2 font-heading font-normal text-[2.75rem] uppercase leading-none",
   "transition-colors duration-200",
   "border-brand-primary bg-transparent text-brand-primary",
+  // Selected pills must not change on hover. The plain hover: classes exist to
+  // knock out the grey hover styles baked into the shadcn toggle base (cn
+  // resolves the conflict in our favour); the data-[state=off] ones then beat
+  // them on CSS specificity so only unselected pills get the hover effect.
   "hover:bg-brand-yellow hover:text-brand-primary data-[state=off]:hover:border-brand-yellow data-[state=off]:hover:text-brand-light-grey",
+  // aria-pressed: is redundant with data-[state=on]: — it's only here to
+  // override the base's aria-pressed:bg-muted.
   "aria-pressed:bg-brand-yellow data-[state=on]:bg-brand-yellow data-[state=on]:border-brand-yellow",
 )
 

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import type { VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+import * as React from "react"
+import { toggleVariants } from "@/components/ui/toggle"
+import { cn } from "@/lib/utils"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 2,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = "horizontal",
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-vertical:flex-col data-vertical:items-stretch data-[size=sm]:rounded-[min(var(--radius-md),10px)]",
+        className,
+      )}
+      data-orientation={orientation}
+      data-size={size}
+      data-slot="toggle-group"
+      data-spacing={spacing}
+      data-variant={variant}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing, orientation }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      className={cn(
+        "shrink-0 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:rounded-none group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      data-size={context.size || size}
+      data-slot="toggle-group-item"
+      data-spacing={context.spacing}
+      data-variant={context.variant || variant}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+import type * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      className={cn(toggleVariants({ variant, size, className }))}
+      data-slot="toggle"
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }


### PR DESCRIPTION
# Description

Adds TogglePillGroup, a reusable two-option toggle built on shadcn/Radix ToggleGroup, restyled to the yellow/outline Figma design. Controlled via value/onChange; options passed as props; clicking the selected option is ignored so one option is always active; sized to match the About page mockup.
Closes #56 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

**Selected EXECUTIVES Button. No hover/No select for COMP TEAM**
<img width="482" height="64" alt="1-initial" src="https://github.com/user-attachments/assets/20beb32f-3e29-4eb3-9a51-5d415debefdd" />

**Selected EXECUTIVES Button. Hover for COMP TEAM**
<img width="482" height="64" alt="2-hover-unselected" src="https://github.com/user-attachments/assets/4301aaf4-7f42-4e2b-9f5d-9fcabf5f1120" />

**Re-selecting EXECUTIVES Button does not deselect it**
<img width="482" height="64" alt="3-hover-selected" src="https://github.com/user-attachments/assets/76e1acca-2812-473c-95ee-94f7234a69ac" />

**Selected COMP TEAM Button. No hover/No select for EXECUTIVES**
<img width="482" height="64" alt="4-after-click-swap" src="https://github.com/user-attachments/assets/1f61941d-5806-438d-89b5-021280d9c2bf" />

**Keyboard selection using tab, shown by blue outline (arrows & enter also work)**
<img width="482" height="64" alt="6-keyboard-enter-focus-ring" src="https://github.com/user-attachments/assets/b3902750-50c9-48fe-b153-48b79b2ebeb0" />


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
