### PR TITLE
chore(navbar): make login link consistent with other nav links

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -6,7 +6,6 @@ import { usePathname } from "next/navigation"
 import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
 
-const BOLD_TEXT_SHADOW = "[text-shadow:0.4px_0_0_currentColor,-0.4px_0_0_currentColor]"
 const HOVER_BOLD_TEXT_SHADOW = "hover:[text-shadow:0.4px_0_0_currentColor,-0.4px_0_0_currentColor]"
 
 const FOCUS_RING =
@@ -32,7 +31,7 @@ function NavLink({
         "group inline-flex items-center gap-1.5 transition-all duration-200 ease-out",
         !isActive && "hover:text-gray-500",
         HOVER_BOLD_TEXT_SHADOW,
-        isActive && `text-primary ${BOLD_TEXT_SHADOW}`,
+        isActive && "text-primary",
         FOCUS_RING,
         className,
       )}

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -28,10 +28,8 @@ function NavLink({
     <Link
       aria-current={isActive ? "page" : undefined}
       className={cn(
-        "group inline-flex items-center gap-1.5 transition-all duration-200 ease-out",
-        !isActive && "hover:text-gray-500",
+        "group inline-flex items-center gap-1.5 text-primary transition-all duration-200 ease-out hover:text-brand-yellow",
         HOVER_BOLD_TEXT_SHADOW,
-        isActive && "text-primary",
         FOCUS_RING,
         className,
       )}
@@ -73,9 +71,7 @@ export function Navbar() {
         <NavLink href="/events">Events</NavLink>
         <NavLink href="/about">About</NavLink>
         <NavLink href="/faq">FAQ</NavLink>
-        <NavLink className="text-primary hover:text-brand-yellow" href="/log-in">
-          Login
-        </NavLink>
+        <NavLink href="/log-in">Login</NavLink>
       </div>
     </nav>
   )


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR fixes an inconsistency in `Navbar` where the "Login" link behaved differently from `Events`, `About`, and `FAQ`.

- removes the unconditional `BOLD_TEXT_SHADOW` applied to the active-link branch in `NavLink`, so `Login` only bolds on hover (via `HOVER_BOLD_TEXT_SHADOW`) like the other links, instead of staying bold whenever `isActive` is true
- moves `hover:text-brand-yellow` into `NavLink`'s shared base classes so all four links hover to the same yellow, instead of only `Login` hardcoding it via `className`
- makes `text-primary` unconditional/shared in `NavLink` so the idle text colour is consistent across all links, and removes the now-redundant `className="text-primary"` override on the `Login` link
- deletes the now-unused `BOLD_TEXT_SHADOW` constant

Note that the active page is still distinguishable via the `>` arrow indicator and `aria-current="page"`, not via a separate colour anymore, since colour is now uniform across all links.

Not related to a ticket

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

<img width="606" height="71" alt="image" src="https://github.com/user-attachments/assets/b3f57c72-fec3-4f2c-9de5-db9ac046c0bd" />

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member