### PR TITLE
fix(statscard): shrink x-multiplier glyph to match figma

### DIFF
--- a/src/components/StatsCards/StatCard.tsx
+++ b/src/components/StatsCards/StatCard.tsx
@@ -17,6 +17,18 @@ export function StatCard({ variant, value, label }: StatCardProps) {
     isNavy ? "text-brand-yellow" : "text-brand-primary group-hover:text-brand-white",
   )
 
+  const multiplierIndex = value.indexOf("x")
+  const valueContent =
+    multiplierIndex === -1 ? (
+      value
+    ) : (
+      <>
+        {value.slice(0, multiplierIndex)}
+        <span className="ml-3 inline-block scale-x-175 align-middle text-[64px]">x</span>
+        {value.slice(multiplierIndex + 1)}
+      </>
+    )
+
   return (
     <Card
       className={cn(
@@ -31,7 +43,7 @@ export function StatCard({ variant, value, label }: StatCardProps) {
             text,
           )}
         >
-          {value}
+          {valueContent}
         </p>
         <p className={cn("font-body font-medium text-xl leading-none", text)}>{label}</p>
       </div>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR fixes the "x" multiplier character in `StatCard` values (e.g. `"2x"`, `"3x"`) rendering at the full `text-[128px]` size instead of the smaller size specified in Figma, where only the "x" itself is meant to shrink, not the whole value.

- locates the `"x"` character in `value` via `multiplierIndex` and splits the string around it, instead of rendering `value` as a single text node
- wraps just the `"x"` character in a `<span>` styled at `text-[64px]` (half the surrounding digit's height), so the digit stays at `128px` and only the multiplier sign shrinks, per Figma
- adds `align-middle` on the `x` span so it's vertically centred against the neighbouring digit instead of sitting on the shared text baseline (the default, which looked misaligned/low)
- adds `scale-x-175` to stretch the `x` glyph 75% wider horizontally per Figma, without affecting its height
- adds `ml-3` for a small gap between the digit and the `x`
- values without an `"x"` (`"10+"`, `"ALL"`) are unaffected, falling through the `multiplierIndex === -1` branch unchanged

Note that earlier iterations (uniformly shrinking the whole value, then also shrinking the `"+"` in `"10+"` to match) were reverted per feedback, since the ask was scoped to just the `"x"` multiplier sign, not other characters.

Not related to a ticket

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member