### PR TITLE
chore(upcoming-events): remove hardcoded background colour

### DIFF
--- a/src/app/(frontend)/log-in/page.tsx
+++ b/src/app/(frontend)/log-in/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <main className="flex min-h-[calc(100vh-96px)] flex-col items-center gap-12 px-6 pt-10 pb-16">
-      <h1 className="text-center font-heading text-8xl uppercase tracking-wide text-brand-primary">
+      <h1 className="text-center font-heading text-8xl text-brand-primary uppercase tracking-wide">
         Login
       </h1>
       <Login />

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -68,7 +68,7 @@ export function Login() {
         </form>
       </Card>
 
-      <p className="text-center text-lg text-brand-primary opacity-80">
+      <p className="text-center text-brand-primary text-lg opacity-80">
         Don&apos;t have an account?{" "}
         <Link
           className="font-semibold transition-all duration-200 ease-in-out hover:underline"

--- a/src/components/UpcomingEvents/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents/UpcomingEvents.tsx
@@ -23,7 +23,7 @@ export default function UpcomingEvents() {
           Upcoming Events
         </h1>
 
-        <p className="mx-auto mt-8 max-w-5xl text-center text-base text-white md:text-xl mb-30">
+        <p className="mx-auto mt-8 mb-30 max-w-5xl text-center text-base text-white md:text-xl">
           The University of Auckland Volleyball Club caters to players of all skill levels, even
           those outside UOA!
         </p>

--- a/src/components/UpcomingEvents/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents/UpcomingEvents.tsx
@@ -17,7 +17,7 @@ const events = [
 
 export default function UpcomingEvents() {
   return (
-    <section className="bg-[#0E2BB3] py-20">
+    <section className="bg-brand-primary py-20">
       <div className="mx-auto max-w-7xl px-6">
         <h1 className="text-center font-heading text-7xl text-white uppercase md:text-9xl">
           Upcoming Events

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -22,7 +22,7 @@ function AccordionItem({
   return (
     <AccordionPrimitive.Item
       className={cn(
-        "w-full overflow-hidden border-2 border-secondary rounded-xl text-[20px] transition-colors duration-300 data-[state=open]:border-primary data-[state=open]:bg-background data-[state=closed]:hover:border-primary data-[state=closed]:hover:bg-transparent",
+        "w-full overflow-hidden rounded-xl border-2 border-secondary text-[20px] transition-colors duration-300 data-[state=open]:border-primary data-[state=open]:bg-background data-[state=closed]:hover:border-primary data-[state=closed]:hover:bg-transparent",
         className,
       )}
       data-slot="accordion-item"
@@ -40,7 +40,7 @@ function AccordionTrigger({
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
         className={cn(
-          "group/accordion-trigger relative flex h-[50px] flex-1 cursor-pointer items-center justify-between px-6 py-8 rounded-md text-left font-semibold text-[20px] text-primary outline-none transition-all duration-300 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white data-[state=open]:border-b-2 data-[state=open]:border-primary **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-10 **:data-[slot=accordion-trigger-icon]:text-foreground shadow-md/20",
+          "group/accordion-trigger relative flex h-[50px] flex-1 cursor-pointer items-center justify-between rounded-md px-6 py-8 text-left font-semibold text-[20px] text-primary shadow-md/20 outline-none transition-all duration-300 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-primary data-[state=open]:border-b-2 data-[state=open]:bg-white **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-10 **:data-[slot=accordion-trigger-icon]:text-foreground",
           className,
         )}
         data-slot="accordion-trigger"
@@ -75,7 +75,7 @@ function AccordionContent({
     >
       <div
         className={cn(
-          "text-primary px-6 py-6 transition-colors hover:bg-transparent [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+          "px-6 py-6 text-primary transition-colors hover:bg-transparent [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
           className,
         )}
       >


### PR DESCRIPTION
# Description

This PR removes a hardcoded hex colour from `UpcomingEvents` in favour of the shared `bg-brand-primary` design token.

- replaces `bg-[#0E2BB3]` with `bg-brand-primary` on the section background in `UpcomingEvents.tsx`, so it pulls from the `--color-brand-primary` CSS variable defined in `globals.css` instead of a one-off magic hex value
- if the brand colour is ever adjusted centrally, this section now follows automatically instead of drifting out of sync with the rest of the site (e.g. `Navbar`, `Footer`, buttons)

Note that the rest of the diff (`Login.tsx`, `log-in/page.tsx`, `accordion.tsx`) is incidental noise from a `chore: lint` commit — Biome's automatic Tailwind class-sorting reordering existing classes, not a deliberate design change.

Not related to a ticket

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member