### PR TITLE
chore(faq): use primary colour for dropdown arrow

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -40,7 +40,7 @@ function AccordionTrigger({
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
         className={cn(
-          "group/accordion-trigger relative flex h-[50px] flex-1 cursor-pointer items-center justify-between rounded-md px-6 py-8 text-left font-semibold text-[20px] text-primary shadow-md/20 outline-none transition-all duration-300 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-primary data-[state=open]:border-b-2 data-[state=open]:bg-white **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-10 **:data-[slot=accordion-trigger-icon]:text-foreground",
+          "group/accordion-trigger relative flex h-[50px] flex-1 cursor-pointer items-center justify-between rounded-md px-6 py-8 text-left font-semibold text-[20px] text-primary shadow-md/20 outline-none transition-all duration-300 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-primary data-[state=open]:border-b-2 data-[state=open]:bg-white **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-10 **:data-[slot=accordion-trigger-icon]:text-primary",
           className,
         )}
         data-slot="accordion-trigger"


### PR DESCRIPTION
# Description

This PR fixes the FAQ accordion's dropdown chevron icon rendering in the wrong shade of blue.

- changes `**:data-[slot=accordion-trigger-icon]:text-foreground` to `**:data-[slot=accordion-trigger-icon]:text-primary` on the `AccordionTrigger` trigger class in `accordion.tsx`, so the `ChevronDownIcon`/`ChevronUpIcon` (rendered with `stroke="currentColor"`) inherits `--color-brand-primary` (`#002cba`) instead of `--foreground`, which resolves to `--color-brand-navy` (`#08345b`)
- matches the icon colour to the trigger's own text (`text-primary`) and open-state border (`data-[state=open]:border-primary`), which already used the brand-primary token

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member