### PR TITLE
chore(comp-team): fix club name typo in team names

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -12,7 +12,7 @@ export function HomePage() {
           { name: "Bob", position: "Midfielder" },
           { name: "Charlie", position: "Defender" },
         ]}
-        teamName="UOACS MEN"
+        teamName="UOAVC MEN"
       />
       <CompTeam
         photo="/team-b.jpg"
@@ -21,7 +21,7 @@ export function HomePage() {
           { name: "Bob", position: "Midfielder" },
           { name: "Charlie", position: "Defender" },
         ]}
-        teamName="UOACS WOMEN"
+        teamName="UOAVC WOMEN"
       />
     </div>
   )


### PR DESCRIPTION
# Description

This PR fixes a typo in the hardcoded `teamName` props on `HomePage`'s two `CompTeam` usages in `src/app/(frontend)/page.tsx`, where the club name was misspelled as "UOACS" instead of "UOAVC".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

Verified both `CompTeam` instances on the homepage now render "UOAVC MEN" and "UOAVC WOMEN".

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member