### PR TITLE
feat(routes): create placeholder site page routes

### DIFF
--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "About",
+}
+
+export default function AboutPage() {
+  return (
+    <main className="flex flex-col items-center px-6 py-20">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+        About
+      </h1>
+    </main>
+  )
+}

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Events",
+}
+
+export default function EventsPage() {
+  return (
+    <main className="flex flex-col items-center px-6 py-20">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+        Events
+      </h1>
+    </main>
+  )
+}

--- a/src/app/(frontend)/faq/page.tsx
+++ b/src/app/(frontend)/faq/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "FAQ",
+}
+
+export default function FaqPage() {
+  return (
+    <main className="flex flex-col items-center px-6 py-20">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+        FAQ
+      </h1>
+    </main>
+  )
+}

--- a/src/app/(frontend)/sign-up/page.tsx
+++ b/src/app/(frontend)/sign-up/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Sign Up",
+}
+
+export default function SignUpPage() {
+  return (
+    <main className="flex flex-col items-center px-6 py-20">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+        Sign Up
+      </h1>
+    </main>
+  )
+}

--- a/src/app/(frontend)/social-sessions/[id]/checkout/cancelled/page.tsx
+++ b/src/app/(frontend)/social-sessions/[id]/checkout/cancelled/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Checkout Cancelled",
+}
+
+export default function CheckoutCancelledPage() {
+  return (
+    <main className="flex flex-col items-center px-6 py-20">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+        Checkout Cancelled
+      </h1>
+    </main>
+  )
+}

--- a/src/app/(frontend)/social-sessions/[id]/checkout/success/page.tsx
+++ b/src/app/(frontend)/social-sessions/[id]/checkout/success/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Checkout Successful",
+}
+
+export default function CheckoutSuccessPage() {
+  return (
+    <main className="flex flex-col items-center px-6 py-20">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+        Checkout Successful
+      </h1>
+    </main>
+  )
+}


### PR DESCRIPTION
# Description

The app only had one real frontend route (`src/app/(frontend)/page.tsx`), so finished components had nowhere to live, and the Stripe checkout endpoint's `success_url`/`cancel_url` (in `src/payload/endpoints/socialSessionCheckout.ts`) pointed at `/social-sessions/[id]/checkout/success` and `/social-sessions/[id]/checkout/cancelled`, which 404'd.

Adds one minimal placeholder `page.tsx` per route — just a centered heading, per the ticket's scope:

- `/events` — `src/app/(frontend)/events/page.tsx`
- `/about` — `src/app/(frontend)/about/page.tsx`
- `/faq` — `src/app/(frontend)/faq/page.tsx`
- `/sign-up` — `src/app/(frontend)/sign-up/page.tsx`
- `/social-sessions/[id]/checkout/success` — `src/app/(frontend)/social-sessions/[id]/checkout/success/page.tsx`
- `/social-sessions/[id]/checkout/cancelled` — `src/app/(frontend)/social-sessions/[id]/checkout/cancelled/page.tsx`

Notes:

- the `[id]` dynamic segment name is chosen to match the `${id}` interpolation in `socialSessionCheckout.ts`'s `success_url`/`cancel_url` template strings, so the checkout redirect resolves correctly
- these pages deliberately don't use the `min-h-[calc(100vh-96px)]` className that `/log-in` (`src/app/(frontend)/log-in/page.tsx`) uses. That pattern forces the page to be at least full-viewport-height, but `Footer` renders after `main` in the same flex column (`src/app/(frontend)/layout.tsx`), so combining the two guarantees the total page height exceeds the viewport and causes unwanted scroll/content overflow — a bug hit and fixed on a different route already. Leaving these placeholders without a forced min-height avoids reintroducing it

This is scoped to just the route files so the paths resolve — no full page implementations.

Closes #92

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

Ran `npm run dev` and confirmed all six routes return HTTP 200: `/events`, `/about`, `/faq`, `/sign-up`, `/social-sessions/<any-id>/checkout/success`, `/social-sessions/<any-id>/checkout/cancelled`. Spot-checked rendered `<title>`/`<h1>` content matches each route.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member