### PR TITLE
chore(components): scale down and resize UI components

### DIFF
--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -9,25 +9,11 @@ type EventCardProps = {
   variant: "upcoming" | "past"
   name: string
   date: string
-  time: string
-  description: string
-  location: string
-  signUpLink?: string
   image?: string
   href: string
 }
 
-export function EventCard({
-  variant,
-  name,
-  date,
-  time,
-  image,
-  href,
-  description,
-  location,
-  signUpLink,
-}: EventCardProps) {
+export function EventCard({ variant, name, date, image, href }: EventCardProps) {
   const isPast = variant === "past"
   const headerBg = isPast ? "bg-brand-yellow" : "bg-brand-primary"
   const borderColor = isPast ? "border-brand-yellow" : "border-brand-primary"
@@ -39,36 +25,37 @@ export function EventCard({
   return (
     <Card
       className={cn(
-        "group hover:-translate-y-3 w-90 translate-y-0 gap-0 overflow-hidden rounded-none border-4 bg-transparent p-0 transition-transform duration-500 ease-in-out",
+        "group hover:-translate-y-[10px] w-[306px] translate-y-0 gap-0 overflow-hidden rounded-none border-[3px] bg-transparent p-0 transition-transform duration-500 ease-in-out",
         borderColor,
       )}
     >
-      <CardHeader className={cn("rounded-none px-5 py-5", headerBg)}>
-        <CardTitle className={cn("font-black font-heading text-6xl uppercase", titleText)}>
+      <CardHeader className={cn("rounded-none px-[17px] py-[17px]", headerBg)}>
+        <CardTitle
+          className={cn("font-black font-heading text-[51px] uppercase leading-none", titleText)}
+        >
           {name}
         </CardTitle>
-        <CardDescription className={cn("mt-3 flex flex-col gap-4 text-2xl leading-none", descText)}>
-          <p>
-            {date} {time}
-          </p>
-          <p>{description}</p>
-          <p>{location}</p>
-          <p>{signUpLink}</p>
+        <CardDescription className={cn("mt-[10px] text-[20px] leading-none", descText)}>
+          <p>{date}</p>
         </CardDescription>
       </CardHeader>
 
       <CardContent className="overflow-hidden bg-transparent px-0">
-        <div className="relative h-72 w-full bg-transparent">
+        <div className="relative h-[245px] w-full bg-transparent">
           {image ? (
-            <Image alt={name} className="object-cover" fill sizes="360px" src={image} />
+            <Image alt={name} className="object-cover" fill sizes="306px" src={image} />
           ) : (
             <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
-              <ImageIcon aria-hidden="true" className="h-10 w-10" />
+              <ImageIcon aria-hidden="true" className="h-[34px] w-[34px]" />
             </div>
           )}
 
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-300 ease-out group-focus-within:bg-brand-primary/15 group-focus-within:opacity-100 group-hover:bg-brand-primary/15 group-hover:opacity-100">
-            <Button asChild className="pointer-events-auto" variant={ctaVariant}>
+            <Button
+              asChild
+              className="pointer-events-auto h-[43px] rounded-[26px] px-[26px] py-[9px] text-[17px]"
+              variant={ctaVariant}
+            >
               <Link href={href}>{ctaLabel}</Link>
             </Button>
           </div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -5,67 +5,67 @@ import { Logo } from "@/components/Logo/Logo"
 export function Footer() {
   return (
     <footer className="bg-brand-primary text-brand-light-grey">
-      <div className="mx-auto px-20 py-10">
+      <div className="mx-auto px-[68px] py-[34px]">
         {/* Main Section */}
-        <div className="flex flex-col gap-12 md:flex-row md:justify-between">
+        <div className="flex flex-col gap-[41px] md:flex-row md:justify-between">
           {/* Title */}
           <div className="max-w-md">
-            <h3 className="inline-block origin-center font-heading text-[2.5rem] uppercase tracking-tight hover:animate-[wiggle_1500ms_ease-out]">
+            <h3 className="inline-block origin-center font-heading text-[34px] uppercase tracking-tight hover:animate-[wiggle_1500ms_ease-out]">
               Contact Us!
             </h3>
             <a
-              className="mt-10 block text-brand-light-grey/90 text-xl"
+              className="mt-[34px] block text-[17px] text-brand-light-grey/90"
               href="mailto:uoavolleyball+secretary@gmail.com"
             >
               uoavolleyball+secretary@gmail.com
             </a>
             {/* Socials */}
-            <div className="mt-6 flex gap-8">
+            <div className="mt-[20px] flex gap-[27px]">
               <a
-                className="group flex h-13 w-13 items-center justify-center rounded-full border-2 border-brand-light-grey transition duration-300 ease-in-out hover:bg-white"
+                className="group flex h-[44px] w-[44px] items-center justify-center rounded-full border-2 border-brand-light-grey transition duration-300 ease-in-out hover:bg-white"
                 href="https://www.instagram.com/uoavc/?hl=en"
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 <FaInstagram
                   className="text-brand-light-grey transition duration-300 ease-in-out group-hover:text-brand-primary"
-                  size={32}
+                  size={27}
                 />
               </a>
 
               <a
-                className="group flex h-13 w-13 items-center justify-center rounded-full border-2 border-brand-light-grey transition duration-300 ease-in-out hover:bg-white"
+                className="group flex h-[44px] w-[44px] items-center justify-center rounded-full border-2 border-brand-light-grey transition duration-300 ease-in-out hover:bg-white"
                 href="https://www.tiktok.com/@uoavc"
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 <FaTiktok
                   className="text-brand-light-grey transition duration-300 ease-in-out group-hover:text-brand-primary"
-                  size={32}
+                  size={27}
                 />
               </a>
 
               <a
-                className="group flex h-13 w-13 items-center justify-center rounded-full border-2 border-brand-light-grey transition duration-300 ease-in-out hover:bg-white"
+                className="group flex h-[44px] w-[44px] items-center justify-center rounded-full border-2 border-brand-light-grey transition duration-300 ease-in-out hover:bg-white"
                 href="https://discord.com/invite/aMDKvsWcyz"
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 <FaDiscord
                   className="text-brand-light-grey transition duration-300 ease-in-out group-hover:text-brand-primary"
-                  size={32}
+                  size={27}
                 />
               </a>
             </div>
           </div>
 
           {/* Page Links */}
-          <div className="flex items-start gap-16 lg:gap-24">
+          <div className="flex items-start gap-[54px] lg:gap-[82px]">
             {/* Events */}
-            <div className="pt-10">
-              <h4 className="mb-4 font-semibold text-xl">Events</h4>
+            <div className="pt-[34px]">
+              <h4 className="mb-[14px] font-semibold text-[17px]">Events</h4>
 
-              <ul className="space-y-2 text-brand-light-grey/90 text-xl">
+              <ul className="space-y-[7px] text-[17px] text-brand-light-grey/90">
                 <li>
                   <Link className="transition hover:underline" href="/events/upcoming">
                     Upcoming Events
@@ -81,10 +81,10 @@ export function Footer() {
             </div>
 
             {/* About */}
-            <div className="pt-10">
-              <h4 className="mb-4 font-semibold text-xl">About</h4>
+            <div className="pt-[34px]">
+              <h4 className="mb-[14px] font-semibold text-[17px]">About</h4>
 
-              <ul className="space-y-2 text-brand-light-grey/90 text-xl">
+              <ul className="space-y-[7px] text-[17px] text-brand-light-grey/90">
                 <li>
                   <Link className="transition hover:underline" href="/events/executives">
                     Executives
@@ -100,10 +100,10 @@ export function Footer() {
             </div>
 
             {/* FAQ */}
-            <div className="pt-10">
-              <h4 className="mb-4 font-semibold text-xl">FAQ</h4>
+            <div className="pt-[34px]">
+              <h4 className="mb-[14px] font-semibold text-[17px]">FAQ</h4>
 
-              <ul className="space-y-2 text-brand-light-grey/90 text-xl">
+              <ul className="space-y-[7px] text-[17px] text-brand-light-grey/90">
                 <li>
                   <Link className="transition hover:underline" href="/events/faq">
                     FAQ
@@ -113,10 +113,10 @@ export function Footer() {
             </div>
 
             {/* Login */}
-            <div className="pt-10">
-              <h4 className="mb-4 font-semibold text-xl">Login</h4>
+            <div className="pt-[34px]">
+              <h4 className="mb-[14px] font-semibold text-[17px]">Login</h4>
 
-              <ul className="space-y-2 text-brand-light-grey/90 text-xl">
+              <ul className="space-y-[7px] text-[17px] text-brand-light-grey/90">
                 <li>
                   <Link className="transition hover:underline" href="/events/signup">
                     Sign Up
@@ -131,15 +131,15 @@ export function Footer() {
             </div>
 
             {/* Logo */}
-            <div className="pt-15">
+            <div className="pt-[51px]">
               <Logo />
             </div>
           </div>
         </div>
 
         {/* Bottom Bar */}
-        <div className="mt-10 border-brand-light-grey/70 border-t pt-4">
-          <p className="text-brand-light-grey text-xl">&copy;2026 UOAVC + WDCC</p>
+        <div className="mt-[34px] border-brand-light-grey/70 border-t pt-[14px]">
+          <p className="text-[17px] text-brand-light-grey">&copy;2026 UOAVC + WDCC</p>
         </div>
       </div>
     </footer>

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -10,10 +10,10 @@ export function Logo() {
       <Image
         alt="UOAVC logo"
         className="transition-transform duration-300 ease-out hover:rotate-20 hover:scale-110"
-        height={64}
+        height={54}
         priority
         src="/logo.svg"
-        width={64}
+        width={54}
       />
     </Link>
   )

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -28,7 +28,7 @@ function NavLink({
     <Link
       aria-current={isActive ? "page" : undefined}
       className={cn(
-        "group inline-flex items-center gap-1.5 text-primary transition-all duration-200 ease-out hover:text-brand-yellow",
+        "group inline-flex items-center gap-[5px] text-primary transition-all duration-200 ease-out hover:text-brand-yellow",
         HOVER_BOLD_TEXT_SHADOW,
         FOCUS_RING,
         className,
@@ -55,19 +55,19 @@ export function Navbar() {
   return (
     <nav
       aria-label="Main"
-      className="sticky top-0 z-50 flex items-center justify-between bg-background py-4 pr-6 pl-6 md:pr-8"
+      className="sticky top-0 z-50 flex items-center justify-between bg-background py-[14px] pr-[20px] pl-[20px] md:pr-[27px]"
     >
       <Link aria-label="UOAVC home" className={FOCUS_RING} href="/">
         <Image
           alt="UOAVC logo"
           className="transition-transform duration-300 ease-out hover:rotate-20 hover:scale-110"
-          height={64}
+          height={54}
           priority
           src="/logo.svg"
-          width={64}
+          width={54}
         />
       </Link>
-      <div className="flex items-center gap-16 text-lg md:gap-20 lg:gap-24">
+      <div className="flex items-center gap-[54px] text-[15px] md:gap-[68px] lg:gap-[82px]">
         <NavLink href="/events">Events</NavLink>
         <NavLink href="/about">About</NavLink>
         <NavLink href="/faq">FAQ</NavLink>

--- a/src/components/UpcomingEvents/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents/UpcomingEvents.tsx
@@ -23,21 +23,21 @@ export default function UpcomingEvents() {
           Upcoming Events
         </h1>
 
-        <p className="mx-auto mt-8 mb-30 max-w-5xl text-center text-base text-white md:text-xl">
+        <p className="mx-auto mt-8 mb-26 max-w-5xl text-center text-base text-white md:text-xl">
           The University of Auckland Volleyball Club caters to players of all skill levels, even
           those outside UOA!
         </p>
 
-        <div className="mt-20 flex flex-wrap justify-center gap-20">
+        <div className="mt-20 flex flex-wrap justify-center gap-6">
           {events.map((event) => (
             <div className="flex w-full max-w-lg flex-col items-center" key={event.title}>
-              <div className="w-full overflow-hidden rounded-lg shadow-lg transition-transform duration-300 hover:scale-110">
+              <div className="w-full max-w-[470px] overflow-hidden rounded-lg shadow-lg transition-transform duration-300 hover:scale-110">
                 <Image
                   alt={event.title}
-                  className="h-96 w-full object-cover"
-                  height={384}
+                  className="h-[306px] w-full object-cover"
+                  height={306}
                   src={event.image}
-                  width={576}
+                  width={510}
                 />
               </div>
 
@@ -45,7 +45,7 @@ export default function UpcomingEvents() {
                 {event.title}
               </h3>
 
-              <div className="mt-10">
+              <div className="mt-6">
                 <Button
                   asChild
                   className="border-2 border-brand-yellow"

--- a/src/components/about/CompTeam/CompTeam.tsx
+++ b/src/components/about/CompTeam/CompTeam.tsx
@@ -15,7 +15,7 @@ const CompTeam = ({ teamName, photo, players }: CompTeamProps) => {
       <h1 className="font-bold text-4xl text-brand-navy">{teamName}</h1>
 
       {photo && (
-        <div className="relative aspect-video w-full max-w-6xl">
+        <div className="relative aspect-video w-full max-w-[922px]">
           <Image alt={teamName} className="bg-gray-300" fill src={photo} />
         </div>
       )}


### PR DESCRIPTION
# Description

This PR scales down `Navbar`, `Footer`, `Logo`, `CompTeam`, and `EventCard` to better match their Figma sizing, resizes `UpcomingEvents`' photos and spacing, and trims `EventCard`'s props down to only what's actually rendered.

### Navbar & Footer (~15% down)

- scales every sized value in `Navbar.tsx` — nav padding, logo dimensions, link gaps, link text size, and the icon gap inside `NavLink` — down by ~15%, computed by hand and rounded to whole pixels
- scales every sized value in `Footer.tsx` — container padding, heading/section gaps, social icon buttons and glyphs, page-link columns, and the bottom bar — down by ~15%
- scales `Logo.tsx`'s `<Image>` dimensions from `64` to `54`, matching `Navbar`'s own logo reduction; `Logo` is only ever rendered inside `Footer`, so this is safe to change without affecting other pages
- leaves `Navbar`'s focus-ring width/offset and `Footer`'s hairline borders (`border-2`, `border-t`) unscaled, since those are accessibility-functional/decorative sizing rather than layout sizing

### CompTeam (20% down)

- reduces the team photo's `max-w-6xl` (1152px) cap to `max-w-[922px]` (1152 × 0.8), the only sized value in the component; `w-full`/`aspect-video` fluid behaviour is unchanged

### EventCard (simplify + 15% down)

- trims `EventCardProps` from `{ variant, name, date, time, description, location, signUpLink?, image?, href }` down to `{ variant, name, date, image?, href }`, removing the unused fields from the type, destructuring, and render entirely rather than just hiding them (the only real call site was a throwaway preview, updated to match)
- scales every remaining sized value by ~15% — card width/border/hover-lift, header padding, title/description text and spacing, image container height, placeholder icon size, and the CTA button's height/padding/text/border-radius
- overrides the CTA sizing via an instance-level `className` on the shared `Button` rather than editing `ui/button.tsx`, since its `size="md"` preset is used elsewhere in the app and shouldn't change globally
- adds `leading-none` to the card title, since the base `CardTitle`'s `leading-snug` left a visibly large gap between wrapped lines once the card got narrower (e.g. "Monday Social" / "Session" wrapping onto two lines)

### UpcomingEvents (resize photos + tighten spacing)

- reduces the description paragraph's `mb-30` to `mb-26` and the cards' `gap-20` to `gap-6`
- caps each photo wrapper at `max-w-[470px]` (previously unconstrained beyond the parent's `max-w-lg`) and resizes the `<Image>` from `576×384` to `510×306` (both the `width`/`height` props and the `h-96` → `h-[306px]` class)
- tightens the gap between each event's title and its "Sign up!" button from `mt-10` to `mt-6`

Note that `UpcomingEvents` isn't a uniform 15% scale-down like the other components — the section's `py-20`, the container's `px-6`, the "Upcoming Events" heading size, the description's font size, and each event title's font size were all reverted back to their original values partway through this work per direct feedback ("scale the text back to normal"), so only the photos and the listed spacing values changed here.

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member