### PR TITLE
fix(hero): correct navbar-height calc and fix text alignment

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -2,14 +2,14 @@ import Image from "next/image"
 
 export function Hero() {
   return (
-    <section className="relative min-h-[calc(100svh-60px)] overflow-hidden md:h-[calc(100svh-96px)] md:min-h-0">
+    <section className="relative min-h-[calc(100svh-82px)] overflow-hidden md:h-[calc(100svh-82px)] md:min-h-0">
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute inset-0 bg-[#F8E4A8] [clip-path:polygon(0_13%,0_100%,76%_100%)]" />
         <div className="absolute inset-0 bg-[#FADA7A] [clip-path:polygon(0_25%,0_100%,65%_100%)]" />
         <div className="absolute inset-0 bg-[#FBD45E] [clip-path:polygon(0_37%,0_100%,55%_100%)]" />
       </div>
 
-      <div className="relative z-10 grid min-h-[calc(100svh-60px)] grid-cols-1 md:h-full md:min-h-0 md:grid-cols-2">
+      <div className="relative z-10 grid min-h-[calc(100svh-82px)] grid-cols-1 md:h-full md:min-h-0 md:grid-cols-2">
         <div className="flex items-center justify-center px-6">
           <div className="relative aspect-[485/583] w-[clamp(180px,min(32vw,57.2vh),485px)]">
             <Image
@@ -24,13 +24,13 @@ export function Hero() {
         </div>
 
         <div className="flex flex-col items-center justify-center px-8 py-[clamp(0.5rem,3vh,2rem)]">
-          <div className="w-full max-w-[657px]">
+          <div className="w-full max-w-[500px]">
             <h1 className="text-center font-heading text-primary">
-              <span className="mx-auto block w-fit origin-center whitespace-nowrap text-[clamp(3rem,min(9.13vw,16.35vh),8.66rem)] leading-[1.15] tracking-[-0.019em] transition-transform duration-500 ease-out hover:scale-[1.149]">
+              <span className="ml-auto block w-fit origin-center whitespace-nowrap text-[clamp(3rem,min(9.13vw,16.35vh),8.66rem)] leading-[1.15] tracking-[-0.019em] transition-transform duration-500 ease-out hover:scale-[1.149]">
                 WELCOME TO
               </span>
 
-              <span className="mx-auto mt-[clamp(-1.5rem,-1.5vh,-0.25rem)] block w-fit origin-center whitespace-nowrap text-[clamp(5.5rem,min(17.62vw,31.55vh),16.72rem)] leading-[1] transition-transform duration-500 ease-out hover:scale-[1.142]">
+              <span className="mt-[clamp(-1.5rem,-1.5vh,-0.25rem)] ml-auto block w-fit origin-center whitespace-nowrap text-[clamp(5.5rem,min(17.62vw,31.55vh),16.72rem)] leading-[1] transition-transform duration-500 ease-out hover:scale-[1.142]">
                 UOAVC
               </span>
             </h1>


### PR DESCRIPTION
# Description

This PR fixes `Hero`'s viewport-height calc falling out of sync with `Navbar`'s actual height, and tightens up the heading/info-block text alignment.

### Navbar-height calc

- changes both height calcs in `Hero.tsx` — `min-h-[calc(100svh-60px)]` (mobile) and `md:h-[calc(100svh-96px)]` (desktop) — to `calc(100svh-82px)` at both breakpoints
- `Navbar`'s height is now `82px` at every breakpoint (only its horizontal padding varies) after `chore(navbar): scale down navbar by 15%` resized it, but `Hero`'s hardcoded height offsets were never updated to match
- this left the desktop `Hero` 14px short of the viewport, revealing `UpcomingEvents`'s `bg-brand-primary` blue background peeking through at the bottom before scrolling
- `82px` matches `Navbar.tsx`'s actual rendered height (`py-[14px]` = 28px + a `height={54}` logo = 82px)

### Text alignment

- switches the heading's `WELCOME TO` and `UOAVC` `<span>`s from `mx-auto` to `ml-auto`, so they anchor to the same edge of their containing block as the info block below (club name + awards list), which already used `ml-auto`
- `mx-auto` only centers each span independently — since the two spans and the info block are all different widths, centering each one never lines up their edges, whereas anchoring all three to the same edge via `ml-auto` does regardless of width
- narrows the shared containing block from `max-w-[657px]` to `max-w-[500px]` to pull the now-flush-right text column further toward the center of its grid column

Note that at very wide viewports the `UOAVC` span (`w-fit`, sized to its own fluid `clamp()` font rather than shrunk to its parent) can render wider than the `500px` containing block and overflow it. This isn't introduced or fully resolved here — `500px` was confirmed to work correctly for the alignment goal, while narrowing further (to `440px`) caused visible overflow.

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member