### PR TITLE
fix(hero): decouple text sizing from centering to prevent overflow

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -24,7 +24,7 @@ export function Hero() {
         </div>
 
         <div className="flex flex-col items-center justify-center px-8 py-[clamp(0.5rem,3vh,2rem)]">
-          <div className="w-full max-w-[500px]">
+          <div className="md:-translate-x-[100px] w-full max-w-[620px]">
             <h1 className="text-center font-heading text-primary">
               <span className="ml-auto block w-fit origin-center whitespace-nowrap text-[clamp(3rem,min(9.13vw,16.35vh),8.66rem)] leading-[1.15] tracking-[-0.019em] transition-transform duration-500 ease-out hover:scale-[1.149]">
                 WELCOME TO


### PR DESCRIPTION
# Description

This PR fixes `Hero`'s heading/info-block container overflowing on wide viewports, a direct follow-up to #109, which set `max-w-[500px]` on the container in order to visually pull the flush-right-aligned hero text (`WELCOME TO` / `UOAVC` / the club info block) toward the center of its grid column.

- widens the container from `max-w-[500px]` to `max-w-[620px]`, since `UOAVC`'s fluid `clamp(5.5rem, min(17.62vw, 31.55vh), 16.72rem)` heading can render up to ~597px wide at the clamp's ceiling — measured against the real Staatliches glyph advance widths (U=460, O=457, A=427, V=433, C=453 out of 1000 units/em, i.e. `UOAVC` is 2.23em wide) — which is wider than the previous `500px` cap
- since the heading `<span>`s are `w-fit` (sized to their own content rather than shrunk to fit the parent), once the viewport was wide enough (~1272px+, and fully broken by ~1518px+ where the clamp hits its max), `UOAVC` overflowed past the container's right edge, breaking the `ml-auto` flush-alignment shared with the other text elements
- moves the centering pull off the container's max-width and onto a separate `md:-translate-x-[100px]` transform, decoupling sizing (how much width the block needs) from positioning (pulling it toward center) so the two concerns can't conflict again
- scopes the transform to `md:` only, since the grid collapses to a single stacked column below that breakpoint (`grid-cols-1` vs `md:grid-cols-2`), where shifting left isn't appropriate on a narrow viewport

Relates to #109

Note that `npx tsc --noEmit` and `npx biome check` are both clean on this file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member