### PR TITLE
feat: add homepage FAQ section

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,11 +1,40 @@
-import { Hero } from "@/components/Hero/Hero"
-import UpcomingEvents from "@/components/UpcomingEvents/UpcomingEvents"
+import { convertLexicalToHTML } from "@payloadcms/richtext-lexical/html"
+import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical"
+import { getPayload } from "payload"
 
-export default function HomePage() {
+import { Hero } from "@/components/Hero/Hero"
+import HomepageFaq from "@/components/HomepageFaq/HomepageFaq"
+import UpcomingEvents from "@/components/UpcomingEvents/UpcomingEvents"
+import config from "@/payload.config"
+
+export const dynamic = "force-dynamic"
+
+export default async function HomePage() {
+  const payload = await getPayload({ config: await config })
+
+  const result = await payload.find({
+    collection: "faqs",
+    where: {
+      published: {
+        equals: true,
+      },
+    },
+    sort: "order",
+    limit: 3,
+  })
+
+  const faqItems = result.docs.map((faq) => ({
+    question: faq.question,
+    answer: convertLexicalToHTML({
+      data: faq.answer as SerializedEditorState,
+    }),
+  }))
+
   return (
     <>
       <Hero />
       <UpcomingEvents />
+      <HomepageFaq items={faqItems} />
     </>
   )
 }

--- a/src/components/HomepageFaq/HomepageFaq.tsx
+++ b/src/components/HomepageFaq/HomepageFaq.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link"
+
+import { Faq } from "@/components/FAQ/FAQ"
+
+interface FaqItem {
+  question: string
+  answer: string
+}
+
+interface HomepageFaqProps {
+  items: FaqItem[]
+}
+
+export default function HomepageFaq({ items }: HomepageFaqProps) {
+  return (
+    <section className="relative overflow-hidden bg-brand-white px-6 py-16 sm:px-8 xl:min-h-[820px] xl:px-0 xl:pt-[102px] xl:pb-[120px]">
+      <div className="pointer-events-none absolute top-0 right-0 hidden h-[333px] w-[572px] xl:block">
+        <div className="absolute inset-0 bg-[#F8E4A8] [clip-path:polygon(0_0,100%_0,100%_100%)]" />
+        <div className="absolute inset-0 bg-[#FADA7A] [clip-path:polygon(27%_0,100%_0,100%_73%)]" />
+        <div className="absolute inset-0 bg-[#FBD45E] [clip-path:polygon(54%_0,100%_0,100%_48%)]" />
+      </div>
+
+      <div className="relative z-10 mx-auto max-w-7xl">
+        <h2 className="mb-4 font-heading text-6xl text-brand-primary uppercase sm:text-7xl xl:text-[140px] xl:leading-none">
+          FAQ
+        </h2>
+
+        <div className="grid gap-12 xl:grid-cols-[800px_257px] xl:gap-[134px]">
+          <div className="min-w-0">
+            <div className="[&_[data-slot=accordion]]:!w-full [&_[data-slot=accordion]]:!px-0 [&_[data-slot=accordion-content]_div]:break-words">
+              <Faq items={items} />
+            </div>
+
+            <div className="mt-6 flex justify-end">
+              <Link
+                className="flex h-[50px] w-[220px] max-w-full items-center justify-center rounded-full border-2 border-brand-primary bg-brand-primary text-base text-white transition-colors hover:bg-transparent hover:text-brand-primary"
+                href="/faq"
+              >
+                More questions &gt;
+              </Link>
+            </div>
+          </div>
+
+          <div className="max-w-[257px] text-brand-primary">
+            <h3 className="mb-9 font-black text-xl uppercase">Still have questions?</h3>
+
+            <p className="mb-6 text-xl leading-normal">
+              If there's anything we haven't covered that you would like to ask, please reach out!
+            </p>
+
+            <p className="text-xl leading-normal">
+              Message us through Email, Instagram, TikTok or Discord provided below.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
# Description

Adds the FAQ section on the homepage according to the Figma design.

- Reuses the existing FAQ accordion component.
- Displays the top 3 published FAQs from Payload CMS, ordered by the existing order field.
- Adds the "More questions >" link to the FAQ page.

Closes #88 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
<img width="1470" height="838" alt="image" src="https://github.com/user-attachments/assets/0363427d-6781-42de-8013-349577009207" />
<img width="1470" height="830" alt="image" src="https://github.com/user-attachments/assets/c1fcf8d1-d144-4ca7-99be-7db320500aaf" />
<img width="1470" height="827" alt="image" src="https://github.com/user-attachments/assets/2a9d084f-be63-4753-a137-7c4d0effc5af" />



## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
