### PR TITLE
feat: assemble homepage stats section

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,11 +1,13 @@
 import { Hero } from "@/components/Hero/Hero"
 import UpcomingEvents from "@/components/UpcomingEvents/UpcomingEvents"
+import { WhoWeAre } from "@/components/WhoWeAre/WhoWeAre"
 
 export default function HomePage() {
   return (
     <>
       <Hero />
       <UpcomingEvents />
+      <WhoWeAre />
     </>
   )
 }

--- a/src/components/StatsCards/StatsCards.tsx
+++ b/src/components/StatsCards/StatsCards.tsx
@@ -9,7 +9,7 @@ const STATS = [
 
 export function StatsCards() {
   return (
-    <div className="flex flex-wrap gap-[50px]">
+    <div className="flex flex-wrap justify-center gap-[50px]">
       {STATS.map((stat) => (
         <StatCard key={stat.label} {...stat} />
       ))}

--- a/src/components/StatsCards/StatsCards.tsx
+++ b/src/components/StatsCards/StatsCards.tsx
@@ -9,7 +9,7 @@ const STATS = [
 
 export function StatsCards() {
   return (
-    <div className="flex flex-wrap justify-center gap-[50px]">
+    <div className="mx-auto grid w-fit grid-cols-1 gap-[50px] md:grid-cols-2 xl:grid-cols-4">
       {STATS.map((stat) => (
         <StatCard key={stat.label} {...stat} />
       ))}

--- a/src/components/WhoWeAre/WhoWeAre.tsx
+++ b/src/components/WhoWeAre/WhoWeAre.tsx
@@ -25,7 +25,7 @@ export function WhoWeAre() {
         </div>
       </div>
 
-      <div className="mt-29 px-6">
+      <div className="mt-29">
         <StatsCards />
       </div>
     </section>

--- a/src/components/WhoWeAre/WhoWeAre.tsx
+++ b/src/components/WhoWeAre/WhoWeAre.tsx
@@ -1,0 +1,33 @@
+import { StatsCards } from "@/components/StatsCards/StatsCards"
+
+export function WhoWeAre() {
+  return (
+    <section className="bg-brand-yellow pt-20 pb-28">
+      <div className="mx-auto max-w-[1180px] px-6 text-center text-brand-primary">
+        <p className="font-heading text-3xl uppercase leading-[1.1] tracking-[-0.019em] md:text-5xl">
+          Who We Are
+        </p>
+
+        <h2 className="mt-4 font-heading text-5xl uppercase leading-none tracking-[-0.019em] md:text-7xl xl:text-[128px]">
+          Built For Every Player
+        </h2>
+
+        <div className="mt-6 text-base md:text-[19px]">
+          <p>
+            The University of Auckland Volleyball Club caters to players of all skill levels – even
+            those outside UoA.
+          </p>
+
+          <p>
+            Whether you’ve never touched a volleyball or you’re looking for competitive play,
+            there’s place for you here.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-29 px-6">
+        <StatsCards />
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

Adds the "Who We Are / Built for Every Player" section to the homepage, wrapping the
existing StatsCards with the yellow background, heading and copy from Figma.

Also switched StatsCards from flex-wrap to a grid so the four cards go 1 / 2 / 4
columns instead of wrapping into a lopsided 3 + 1.

**Just a note:**
The statement "The University of Auckland Volleyball Club caters to players of all skill levels, even those outside UOA" appears in back to back sections (the upcoming events section and the stats section on the homepage) so looks a bit redundant, though not a big issue, we could change one of those statements to something different.

Closes #87  <!-- Remove if not linked to an issue -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

**Homepage Preview:**

https://github.com/user-attachments/assets/6bab5bed-4567-450c-b348-3bc4d6deae89

**Statscard grid fix (isn't perfect so open to feedback/suggestions)**

https://github.com/user-attachments/assets/29e7d068-25e1-49dc-8100-bd0bca082ee9

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I've requested a review from another team member
