### PR TITLE
chore(event-card): round card corners

### DIFF
--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -25,7 +25,7 @@ export function EventCard({ variant, name, date, image, href }: EventCardProps) 
   return (
     <Card
       className={cn(
-        "group hover:-translate-y-[10px] w-[306px] translate-y-0 gap-0 overflow-hidden rounded-none border-[3px] bg-transparent p-0 transition-transform duration-500 ease-in-out",
+        "group hover:-translate-y-[10px] w-[306px] translate-y-0 gap-0 overflow-hidden rounded-xl border-[3px] bg-transparent p-0 transition-transform duration-500 ease-in-out",
         borderColor,
       )}
     >


### PR DESCRIPTION
# Description

This PR rounds the corners of `EventCard`'s outer `Card` element, per direct design feedback.

- changes `rounded-none` to `rounded-xl` on the `Card` `className` in `EventCard.tsx`
- because `Card` already has `overflow-hidden`, rounding just the outer element is enough — the `CardHeader` and event photo beneath it clip to match the new rounded shape, even though their own inner classNames still read `rounded-none`

Note that this was verified against the rendered `/events` page in the dev server — the card's class list now reads `rounded-xl`, and the header/image clip correctly to the rounded shape. `npx tsc --noEmit` and `npx biome check` are both clean on this file.

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member