### PR TITLE
chore(homepage): rename UpcomingEvents to SocialSessions

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -4,7 +4,7 @@ import { getPayload } from "payload"
 
 import { Hero } from "@/components/Hero/Hero"
 import HomepageFaq from "@/components/HomepageFaq/HomepageFaq"
-import UpcomingEvents from "@/components/UpcomingEvents/UpcomingEvents"
+import SocialSessions from "@/components/SocialSessions/SocialSessions"
 import { WhoWeAre } from "@/components/WhoWeAre/WhoWeAre"
 import config from "@/payload.config"
 
@@ -34,7 +34,7 @@ export default async function HomePage() {
   return (
     <>
       <Hero />
-      <UpcomingEvents />
+      <SocialSessions />
       <WhoWeAre />
       <HomepageFaq items={faqItems} />
     </>

--- a/src/components/SocialSessions/SocialSessions.tsx
+++ b/src/components/SocialSessions/SocialSessions.tsx
@@ -2,7 +2,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 
-const events = [
+const socialSessions = [
   {
     title: "MONDAY SOCIAL SESSION",
     image: "/eventimage.avif",
@@ -15,12 +15,12 @@ const events = [
   },
 ]
 
-export default function UpcomingEvents() {
+export default function SocialSessions() {
   return (
     <section className="bg-brand-primary py-20">
       <div className="mx-auto max-w-7xl px-6">
         <h1 className="text-center font-heading text-7xl text-white uppercase md:text-9xl">
-          Upcoming Events
+          Social Sessions
         </h1>
 
         <p className="mx-auto mt-8 mb-26 max-w-5xl text-center text-base text-white md:text-xl">
@@ -29,20 +29,20 @@ export default function UpcomingEvents() {
         </p>
 
         <div className="mt-20 flex flex-wrap justify-center gap-6">
-          {events.map((event) => (
-            <div className="flex w-full max-w-lg flex-col items-center" key={event.title}>
+          {socialSessions.map((session) => (
+            <div className="flex w-full max-w-lg flex-col items-center" key={session.title}>
               <div className="w-full max-w-[470px] overflow-hidden rounded-lg shadow-lg transition-transform duration-300 hover:scale-110">
                 <Image
-                  alt={event.title}
+                  alt={session.title}
                   className="h-[306px] w-full object-cover"
                   height={306}
-                  src={event.image}
+                  src={session.image}
                   width={510}
                 />
               </div>
 
               <h3 className="mt-8 text-center font-heading text-4xl text-white uppercase md:text-5xl">
-                {event.title}
+                {session.title}
               </h3>
 
               <div className="mt-6">
@@ -52,7 +52,7 @@ export default function UpcomingEvents() {
                   size="md"
                   variant="tertiary"
                 >
-                  <Link href={event.link}>Sign up!</Link>
+                  <Link href={session.link}>Sign up!</Link>
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
# Description

This PR renames `UpcomingEvents` to `SocialSessions` throughout the homepage to match the section's actual content, which has always been the club's recurring "Monday/Friday Social Session" events rather than a generic list of upcoming events.

- renames `src/components/UpcomingEvents/UpcomingEvents.tsx` to `src/components/SocialSessions/SocialSessions.tsx`
- renames the `UpcomingEvents` component/default export to `SocialSessions`, the internal `events` array to `socialSessions`, and the `.map((event) => ...)` callback parameter to `session` (and all its usages: `session.title`, `session.image`, `session.link`)
- changes the visible `<h1>` heading text from "Upcoming Events" to "Social Sessions"
- updates `src/app/(frontend)/page.tsx` to import and render `SocialSessions` instead of `UpcomingEvents`

Note that `Footer.tsx`'s nav link labelled "Upcoming Events" (pointing to `/events/upcoming`) and the `/events` page's own "Upcoming Events" section heading were both deliberately left unchanged — they refer to a real route/filter concept on the separate events listing page, not this homepage section.

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member