### PR TITLE
feat(events): add "Show less" link to collapse past events

### DIFF
--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -107,6 +107,14 @@ export default async function EventsPage({
             </Link>
           </Button>
         ) : null}
+
+        {showAllPast && pastEvents.docs.length > EVENTS_PER_ROW ? (
+          <Button asChild className="mt-7 mb-18" size="md" variant="primary">
+            <Link href="/events" scroll={false}>
+              Show less
+            </Link>
+          </Button>
+        ) : null}
       </section>
     </div>
   )


### PR DESCRIPTION
# Description

This PR adds a "Show less" link back to the paginated `/events` view, giving users a way to collapse the past events list after expanding it with "Load more".

- adds a `<Button asChild>` / `<Link href="/events" scroll={false}>` reading "Show less" in `src/app/(frontend)/events/page.tsx`, rendered when `showAllPast` is true and `pastEvents.docs.length > EVENTS_PER_ROW`
- follows the same server-driven pattern as the existing "Load more" link — no new client state, just a plain navigation that drops the `?past=all` query param so the page re-fetches the paginated view
- guards on `pastEvents.docs.length > EVENTS_PER_ROW` so "Show less" only appears when there were actually more past events than fit on one page, avoiding a pointless collapse option when nothing would visibly change

Previously, once `/events?past=all` was loaded there was no way back — the "Load more" button's own conditional (`!showAllPast && pastEvents.hasNextPage`) meant nothing rendered in its place once `showAllPast` became true.

Note that this was verified against the rendered `/events` and `/events?past=all` routes in the dev server — `/events` renders "Load more" while `/events?past=all` renders "Show less" instead. `npx tsc --noEmit` and `npx biome check` are both clean.

Not related to a ticket

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member