### PR TITLE
chore(frontend): rescale spacing/typography to consistent Tailwind scale

### DIFF
--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -19,11 +19,11 @@ export default async function AboutPage() {
   return (
     <div className="flex flex-col items-center gap-8 bg-background px-6 py-6">
       <section className="flex flex-col items-center gap-6">
-        <h1 className="text-center font-heading text-[110px] text-brand-primary uppercase tracking-wide">
+        <h1 className="text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
           About
         </h1>
         {/* Placeholder hardcoded text - no payload collection for about page text */}
-        <p className="my-4 max-w-[974px] px-2 py-4 text-center font-body text-[20px] text-brand-primary">
+        <p className="my-4 max-w-xl px-2 py-4 text-center font-body text-brand-primary text-sm md:text-base">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
           ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
           ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in

--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -17,13 +17,13 @@ export default async function AboutPage() {
   ])
 
   return (
-    <div className="flex flex-col items-center gap-8 bg-background px-6 py-6">
+    <div className="flex flex-col items-center gap-8 bg-background px-6 pt-12 pb-24">
       <section className="flex flex-col items-center gap-6">
-        <h1 className="text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
+        <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
           About
         </h1>
         {/* Placeholder hardcoded text - no payload collection for about page text */}
-        <p className="my-4 max-w-xl px-2 py-4 text-center font-body text-brand-primary text-sm md:text-base">
+        <p className="mb-6 max-w-3xl text-center font-body text-brand-primary text-sm md:text-base">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
           ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
           ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -50,18 +50,23 @@ export default async function EventsPage({
   ])
 
   return (
-    <div className="flex flex-col items-center gap-8 bg-background px-6 py-6">
+    <div className="flex flex-col items-center gap-32 bg-background px-6 pt-20 pb-6">
       <section className="flex flex-col items-center gap-6">
-        <h1 className="mb-18 text-center font-heading text-[110px] text-brand-primary uppercase tracking-wide">
+        <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
           Upcoming Events
         </h1>
+
+        <p className="mb-16 max-w-xl text-center text-brand-primary text-sm md:text-base">
+          Where members register to learn new skills, connect with fellow players, and simply enjoy
+          the good vibes of a session together.
+        </p>
 
         {upcoming.docs.length === 0 ? (
           <p className="text-center font-body text-brand-primary text-lg">
             No upcoming events right now — check back soon.
           </p>
         ) : (
-          <div className="flex max-w-[982px] flex-wrap justify-center gap-8 md:justify-start">
+          <div className="flex w-full max-w-[982px] flex-wrap justify-center gap-8">
             {upcoming.docs.map((event) => (
               <EventCard
                 date={dateFormatter.format(new Date(event.date))}
@@ -77,16 +82,21 @@ export default async function EventsPage({
       </section>
 
       <section className="flex flex-col items-center gap-6">
-        <h2 className="m-18 text-center font-heading text-[110px] text-brand-primary uppercase tracking-wide">
+        <h2 className="mt-18 mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
           Past Events
         </h2>
+
+        <p className="mb-16 max-w-xl text-center text-brand-primary text-sm md:text-base">
+          A look back at the sessions, socials, and tournaments we've shared as a club, and a
+          reminder of the memories and friendships made along the way.
+        </p>
 
         {pastEvents.docs.length === 0 ? (
           <p className="text-center font-body text-brand-primary text-lg">
             No past events to display.
           </p>
         ) : (
-          <div className="flex max-w-[982px] flex-wrap justify-center gap-8 md:justify-start">
+          <div className="flex w-full max-w-[982px] flex-wrap justify-center gap-8">
             {pastEvents.docs.map((event) => (
               <EventCard
                 date={dateFormatter.format(new Date(event.date))}
@@ -101,7 +111,7 @@ export default async function EventsPage({
         )}
 
         {!showAllPast && pastEvents.hasNextPage ? (
-          <Button asChild className="mt-7 mb-18" size="md" variant="primary">
+          <Button asChild className="mt-7 mb-32" size="md" variant="primary">
             <Link href="/events?past=all" scroll={false}>
               Load more
             </Link>
@@ -109,7 +119,7 @@ export default async function EventsPage({
         ) : null}
 
         {showAllPast && pastEvents.docs.length > EVENTS_PER_ROW ? (
-          <Button asChild className="mt-7 mb-18" size="md" variant="primary">
+          <Button asChild className="mt-7 mb-32" size="md" variant="primary">
             <Link href="/events" scroll={false}>
               Show less
             </Link>

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -50,7 +50,7 @@ export default async function EventsPage({
   ])
 
   return (
-    <div className="flex flex-col items-center gap-32 bg-background px-6 pt-20 pb-6">
+    <div className="flex flex-col items-center gap-20 bg-background px-6 pt-12 pb-32">
       <section className="flex flex-col items-center gap-6">
         <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
           Upcoming Events
@@ -111,7 +111,7 @@ export default async function EventsPage({
         )}
 
         {!showAllPast && pastEvents.hasNextPage ? (
-          <Button asChild className="mt-7 mb-32" size="md" variant="primary">
+          <Button asChild className="mt-7 mb-0" size="md" variant="primary">
             <Link href="/events?past=all" scroll={false}>
               Load more
             </Link>
@@ -119,7 +119,7 @@ export default async function EventsPage({
         ) : null}
 
         {showAllPast && pastEvents.docs.length > EVENTS_PER_ROW ? (
-          <Button asChild className="mt-7 mb-32" size="md" variant="primary">
+          <Button asChild className="mt-7 mb-0" size="md" variant="primary">
             <Link href="/events" scroll={false}>
               Show less
             </Link>

--- a/src/app/(frontend)/faq/page.tsx
+++ b/src/app/(frontend)/faq/page.tsx
@@ -18,10 +18,14 @@ export default async function FaqPage() {
   }))
 
   return (
-    <main className="flex flex-col items-center px-6 py-20">
-      <h1 className="mb-30 text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+    <main className="flex flex-col items-center gap-6 px-6 pt-12 pb-20">
+      <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
         FAQ
       </h1>
+      <p className="mb-16 max-w-lg text-center font-body text-brand-primary text-sm md:text-base">
+        Answers to the questions we get asked most, so you know exactly what to expect and feel
+        ready before you join us.
+      </p>
       <FaqClient faqs={faqs} />
     </main>
   )

--- a/src/app/(frontend)/log-in/page.tsx
+++ b/src/app/(frontend)/log-in/page.tsx
@@ -8,11 +8,11 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <main className="flex min-h-[calc(100vh-96px)] flex-col items-center gap-12 px-6 pt-10 pb-16">
-      <h1 className="text-center font-heading text-8xl text-brand-primary uppercase tracking-wide">
+    <div className="flex min-h-[calc(100svh-82px)] flex-col items-center justify-center gap-12 px-6 pt-12 pb-28">
+      <h1 className="text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
         Login
       </h1>
       <Login />
-    </main>
+    </div>
   )
 }

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -25,35 +25,35 @@ export function EventCard({ variant, name, date, image, href }: EventCardProps) 
   return (
     <Card
       className={cn(
-        "group hover:-translate-y-[10px] w-[306px] translate-y-0 gap-0 overflow-hidden rounded-xl border-[3px] bg-transparent p-0 transition-transform duration-500 ease-in-out",
+        "group hover:-translate-y-2 w-65 translate-y-0 gap-0 overflow-hidden rounded-xl border-2 bg-transparent p-0 transition-transform duration-500 ease-in-out",
         borderColor,
       )}
     >
-      <CardHeader className={cn("rounded-none px-[17px] py-[17px]", headerBg)}>
+      <CardHeader className={cn("rounded-none px-4 py-4", headerBg)}>
         <CardTitle
-          className={cn("font-black font-heading text-[51px] uppercase leading-none", titleText)}
+          className={cn("font-heading font-normal text-5xl uppercase leading-none", titleText)}
         >
           {name}
         </CardTitle>
-        <CardDescription className={cn("mt-[10px] text-[20px] leading-none", descText)}>
+        <CardDescription className={cn("mt-2 text-base leading-none", descText)}>
           <p>{date}</p>
         </CardDescription>
       </CardHeader>
 
       <CardContent className="overflow-hidden bg-transparent px-0">
-        <div className="relative h-[245px] w-full bg-transparent">
+        <div className="relative h-52 w-full bg-transparent">
           {image ? (
-            <Image alt={name} className="object-cover" fill sizes="306px" src={image} />
+            <Image alt={name} className="object-cover" fill sizes="260px" src={image} />
           ) : (
             <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
-              <ImageIcon aria-hidden="true" className="h-[34px] w-[34px]" />
+              <ImageIcon aria-hidden="true" className="h-7 w-7" />
             </div>
           )}
 
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-300 ease-out group-focus-within:bg-brand-primary/15 group-focus-within:opacity-100 group-hover:bg-brand-primary/15 group-hover:opacity-100">
             <Button
               asChild
-              className="pointer-events-auto h-[43px] rounded-[26px] px-[26px] py-[9px] text-[17px]"
+              className="pointer-events-auto h-9 rounded-full px-6 py-2 text-sm"
               variant={ctaVariant}
             >
               <Link href={href}>{ctaLabel}</Link>

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -17,8 +17,8 @@ export function EventCard({ variant, name, date, image, href }: EventCardProps) 
   const isPast = variant === "past"
   const headerBg = isPast ? "bg-brand-yellow" : "bg-brand-primary"
   const borderColor = isPast ? "border-brand-yellow" : "border-brand-primary"
-  const titleText = isPast ? "text-secondary-foreground" : "text-white"
-  const descText = isPast ? "text-secondary-foreground" : "text-white"
+  const titleText = isPast ? "text-brand-primary" : "text-white"
+  const descText = isPast ? "text-brand-primary" : "text-white"
   const ctaLabel = isPast ? "view gallery" : "learn more"
   const ctaVariant = isPast ? "secondary" : "tertiary"
 

--- a/src/components/HomepageFaq/HomepageFaq.tsx
+++ b/src/components/HomepageFaq/HomepageFaq.tsx
@@ -25,7 +25,7 @@ export default function HomepageFaq({ items }: HomepageFaqProps) {
           FAQ
         </h2>
 
-        <div className="grid gap-12 xl:grid-cols-[800px_257px] xl:gap-[134px]">
+        <div className="grid gap-12 xl:grid-cols-[1fr_257px] xl:gap-30">
           <div className="min-w-0">
             <div className="[&_[data-slot=accordion]]:!w-full [&_[data-slot=accordion]]:!px-0 [&_[data-slot=accordion-content]_div]:break-words">
               <Faq items={items} />

--- a/src/components/HomepageFaq/HomepageFaq.tsx
+++ b/src/components/HomepageFaq/HomepageFaq.tsx
@@ -20,8 +20,8 @@ export default function HomepageFaq({ items }: HomepageFaqProps) {
         <div className="absolute inset-0 bg-[#FBD45E] [clip-path:polygon(54%_0,100%_0,100%_48%)]" />
       </div>
 
-      <div className="relative z-10 mx-auto max-w-7xl">
-        <h2 className="mb-4 font-heading text-6xl text-brand-primary uppercase sm:text-7xl xl:text-[140px] xl:leading-none">
+      <div className="relative z-10 mx-auto max-w-7xl pt-30">
+        <h2 className="mb-12 font-heading text-8xl text-brand-primary uppercase md:text-8xl xl:leading-none">
           FAQ
         </h2>
 

--- a/src/components/HomepageFaq/HomepageFaq.tsx
+++ b/src/components/HomepageFaq/HomepageFaq.tsx
@@ -13,44 +13,46 @@ interface HomepageFaqProps {
 
 export default function HomepageFaq({ items }: HomepageFaqProps) {
   return (
-    <section className="relative overflow-hidden bg-brand-white px-6 py-16 sm:px-8 xl:min-h-[820px] xl:px-0 xl:pt-[102px] xl:pb-[120px]">
+    <section className="relative overflow-hidden bg-brand-white px-6 py-16 sm:px-8 xl:min-h-[820px] xl:px-0">
       <div className="pointer-events-none absolute top-0 right-0 hidden h-[333px] w-[572px] xl:block">
         <div className="absolute inset-0 bg-[#F8E4A8] [clip-path:polygon(0_0,100%_0,100%_100%)]" />
         <div className="absolute inset-0 bg-[#FADA7A] [clip-path:polygon(27%_0,100%_0,100%_73%)]" />
         <div className="absolute inset-0 bg-[#FBD45E] [clip-path:polygon(54%_0,100%_0,100%_48%)]" />
       </div>
 
-      <div className="relative z-10 mx-auto max-w-7xl pt-30">
-        <h2 className="mb-12 font-heading text-8xl text-brand-primary uppercase md:text-8xl xl:leading-none">
-          FAQ
-        </h2>
+      <div className="relative z-10 mx-auto max-w-7xl pt-30 pb-30">
+        <div className="xl:mx-auto xl:w-fit">
+          <h2 className="mb-12 font-heading text-8xl text-brand-primary uppercase md:text-8xl xl:leading-none">
+            FAQ
+          </h2>
 
-        <div className="grid gap-12 xl:grid-cols-[1fr_257px] xl:gap-30">
-          <div className="min-w-0">
-            <div className="[&_[data-slot=accordion]]:!w-full [&_[data-slot=accordion]]:!px-0 [&_[data-slot=accordion-content]_div]:break-words">
-              <Faq items={items} />
+          <div className="grid gap-12 xl:grid-cols-[800px_257px] xl:gap-30">
+            <div className="min-w-0">
+              <div className="[&_[data-slot=accordion]]:!w-full [&_[data-slot=accordion]]:!px-0 [&_[data-slot=accordion-content]_div]:break-words">
+                <Faq items={items} />
+              </div>
+
+              <div className="mt-6 flex justify-end">
+                <Link
+                  className="flex h-[50px] w-[220px] max-w-full items-center justify-center rounded-full border-2 border-brand-primary bg-brand-primary text-base text-white transition-colors hover:bg-transparent hover:text-brand-primary"
+                  href="/faq"
+                >
+                  More questions &gt;
+                </Link>
+              </div>
             </div>
 
-            <div className="mt-6 flex justify-end">
-              <Link
-                className="flex h-[50px] w-[220px] max-w-full items-center justify-center rounded-full border-2 border-brand-primary bg-brand-primary text-base text-white transition-colors hover:bg-transparent hover:text-brand-primary"
-                href="/faq"
-              >
-                More questions &gt;
-              </Link>
+            <div className="max-w-[257px] text-brand-primary">
+              <h3 className="mb-9 font-black text-xl uppercase">Still have questions?</h3>
+
+              <p className="mb-6 text-xl leading-normal">
+                If there's anything we haven't covered that you would like to ask, please reach out!
+              </p>
+
+              <p className="text-xl leading-normal">
+                Message us through Email, Instagram, TikTok or Discord provided below.
+              </p>
             </div>
-          </div>
-
-          <div className="max-w-[257px] text-brand-primary">
-            <h3 className="mb-9 font-black text-xl uppercase">Still have questions?</h3>
-
-            <p className="mb-6 text-xl leading-normal">
-              If there's anything we haven't covered that you would like to ask, please reach out!
-            </p>
-
-            <p className="text-xl leading-normal">
-              Message us through Email, Instagram, TikTok or Discord provided below.
-            </p>
           </div>
         </div>
       </div>

--- a/src/components/HomepageFaq/HomepageFaq.tsx
+++ b/src/components/HomepageFaq/HomepageFaq.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 
 import { Faq } from "@/components/FAQ/FAQ"
+import { Button } from "@/components/ui/button"
 
 interface FaqItem {
   question: string
@@ -33,12 +34,9 @@ export default function HomepageFaq({ items }: HomepageFaqProps) {
               </div>
 
               <div className="mt-6 flex justify-end">
-                <Link
-                  className="flex h-[50px] w-[220px] max-w-full items-center justify-center rounded-full border-2 border-brand-primary bg-brand-primary text-base text-white transition-colors hover:bg-transparent hover:text-brand-primary"
-                  href="/faq"
-                >
-                  More questions &gt;
-                </Link>
+                <Button asChild size="md" variant="primary">
+                  <Link href="/faq">More questions &gt;</Link>
+                </Button>
               </div>
             </div>
 

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -16,9 +16,9 @@ export function Login() {
   }
 
   return (
-    <div className="flex w-xl max-w-md flex-col gap-6">
+    <div className="flex w-xl max-w-102 flex-col gap-6">
       <Card
-        className="items-stretch gap-6 rounded-xl border-2 border-brand-primary bg-transparent px-6 py-10 ring-0"
+        className="items-stretch gap-6 rounded-xl border-2 border-brand-primary bg-transparent px-6 py-6 ring-0"
         size="default"
       >
         <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
@@ -43,7 +43,7 @@ export function Login() {
 
           <div className="flex justify-end">
             <Link
-              className="text-brand-primary text-xl opacity-80 transition-all duration-200 ease-in-out hover:underline"
+              className="text-base text-brand-primary opacity-80 transition-all duration-200 ease-in-out hover:underline"
               href="/forgot-password"
             >
               Forgot password?
@@ -58,7 +58,7 @@ export function Login() {
         </form>
       </Card>
 
-      <p className="text-center text-brand-primary text-lg opacity-80">
+      <p className="text-center text-base text-brand-primary opacity-80">
         Don&apos;t have an account?{" "}
         <Link
           className="font-semibold transition-all duration-200 ease-in-out hover:underline"

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -38,12 +38,7 @@ function NavLink({
       {children}
       <span
         aria-hidden="true"
-        className={cn(
-          "transition-all duration-200 ease-out",
-          isActive
-            ? "translate-x-0 opacity-100"
-            : "-translate-x-1 opacity-0 group-hover:translate-x-0 group-hover:opacity-100",
-        )}
+        className="-translate-x-1 opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100"
       >
         &gt;
       </span>

--- a/src/components/SocialSessions/SocialSessions.tsx
+++ b/src/components/SocialSessions/SocialSessions.tsx
@@ -19,7 +19,7 @@ export default function SocialSessions() {
   return (
     <section className="bg-brand-primary py-20">
       <div className="mx-auto max-w-7xl px-5">
-        <h1 className="text-center font-heading text-6xl text-white uppercase md:text-8xl">
+        <h1 className="text-center font-heading text-8xl text-white uppercase md:text-8xl">
           Social Sessions
         </h1>
 

--- a/src/components/SocialSessions/SocialSessions.tsx
+++ b/src/components/SocialSessions/SocialSessions.tsx
@@ -18,34 +18,38 @@ const socialSessions = [
 export default function SocialSessions() {
   return (
     <section className="bg-brand-primary py-20">
-      <div className="mx-auto max-w-7xl px-6">
-        <h1 className="text-center font-heading text-7xl text-white uppercase md:text-9xl">
+      <div className="mx-auto max-w-7xl px-5">
+        <h1 className="text-center font-heading text-6xl text-white uppercase md:text-8xl">
           Social Sessions
         </h1>
 
-        <p className="mx-auto mt-8 mb-26 max-w-5xl text-center text-base text-white md:text-xl">
+        <p className="mx-auto mt-7 max-w-5xl text-center text-sm text-white md:text-base">
           The University of Auckland Volleyball Club caters to players of all skill levels, even
           those outside UOA!
         </p>
+        <p className="mx-auto mb-18 max-w-5xl text-center text-sm text-white md:text-base">
+          Beginners, pros, and everyone in between, come train, compete, and connect with our
+          volleyball community.
+        </p>
 
-        <div className="mt-20 flex flex-wrap justify-center gap-6">
+        <div className="mt-16 flex flex-wrap justify-center gap-14">
           {socialSessions.map((session) => (
-            <div className="flex w-full max-w-lg flex-col items-center" key={session.title}>
-              <div className="w-full max-w-[470px] overflow-hidden rounded-lg shadow-lg transition-transform duration-300 hover:scale-110">
+            <div className="flex w-full max-w-sm flex-col items-center" key={session.title}>
+              <div className="w-full max-w-sm overflow-hidden rounded-lg shadow-lg transition-transform duration-300 hover:scale-110">
                 <Image
                   alt={session.title}
-                  className="h-[306px] w-full object-cover"
-                  height={306}
+                  className="h-64 w-full object-cover"
+                  height={256}
                   src={session.image}
-                  width={510}
+                  width={427}
                 />
               </div>
 
-              <h3 className="mt-8 text-center font-heading text-4xl text-white uppercase md:text-5xl">
+              <h3 className="mt-7 text-center font-heading text-3xl text-white uppercase md:text-4xl">
                 {session.title}
               </h3>
 
-              <div className="mt-6">
+              <div className="mt-5">
                 <Button
                   asChild
                   className="border-2 border-brand-yellow"

--- a/src/components/StatsCards/StatCard.tsx
+++ b/src/components/StatsCards/StatCard.tsx
@@ -24,7 +24,7 @@ export function StatCard({ variant, value, label }: StatCardProps) {
     ) : (
       <>
         {value.slice(0, multiplierIndex)}
-        <span className="ml-3 inline-block scale-x-175 align-middle text-[64px]">x</span>
+        <span className="ml-2.5 inline-block scale-x-175 align-middle text-5xl">x</span>
         {value.slice(multiplierIndex + 1)}
       </>
     )
@@ -32,20 +32,20 @@ export function StatCard({ variant, value, label }: StatCardProps) {
   return (
     <Card
       className={cn(
-        "group h-[199px] w-[280px] items-start justify-center gap-0 rounded-[10px] px-[30px] py-5 text-left ring-0 transition-colors duration-500",
+        "group h-40 w-60 items-start justify-center gap-0 rounded-lg px-6 py-4 text-left ring-0 transition-colors duration-500",
         bg,
       )}
     >
-      <div className="flex h-[159px] w-full flex-col">
+      <div className="flex h-32 w-full flex-col">
         <p
           className={cn(
-            "font-heading font-normal text-[128px] uppercase leading-none tracking-[-0.019em]",
+            "font-heading font-normal text-8xl uppercase leading-none tracking-tight",
             text,
           )}
         >
           {valueContent}
         </p>
-        <p className={cn("font-body font-medium text-xl leading-none", text)}>{label}</p>
+        <p className={cn("font-body font-medium text-base leading-none", text)}>{label}</p>
       </div>
     </Card>
   )

--- a/src/components/StatsCards/StatCard.tsx
+++ b/src/components/StatsCards/StatCard.tsx
@@ -32,11 +32,11 @@ export function StatCard({ variant, value, label }: StatCardProps) {
   return (
     <Card
       className={cn(
-        "group h-40 w-60 items-start justify-center gap-0 rounded-lg px-6 py-4 text-left ring-0 transition-colors duration-500",
+        "group h-42 w-52 items-start justify-center gap-0 rounded-lg px-5 py-3 text-left ring-0 transition-colors duration-500",
         bg,
       )}
     >
-      <div className="flex h-32 w-full flex-col">
+      <div className="flex h-28 w-full flex-col">
         <p
           className={cn(
             "font-heading font-normal text-8xl uppercase leading-none tracking-tight",

--- a/src/components/StatsCards/StatsCards.tsx
+++ b/src/components/StatsCards/StatsCards.tsx
@@ -9,7 +9,7 @@ const STATS = [
 
 export function StatsCards() {
   return (
-    <div className="mx-auto grid w-fit grid-cols-1 gap-[50px] md:grid-cols-2 xl:grid-cols-4">
+    <div className="mx-auto grid w-fit grid-cols-1 gap-11 md:grid-cols-2 xl:grid-cols-4">
       {STATS.map((stat) => (
         <StatCard key={stat.label} {...stat} />
       ))}

--- a/src/components/WhoWeAre/WhoWeAre.tsx
+++ b/src/components/WhoWeAre/WhoWeAre.tsx
@@ -2,15 +2,15 @@ import { StatsCards } from "@/components/StatsCards/StatsCards"
 
 export function WhoWeAre() {
   return (
-    <section className="bg-brand-yellow pt-20 pb-28">
+    <section className="bg-brand-yellow py-32">
       <div className="mx-auto max-w-[1180px] px-6 text-center text-brand-primary">
         <p className="font-heading text-3xl uppercase leading-[1.1] tracking-[-0.019em] md:text-5xl">
           Who We Are
         </p>
 
-        <h2 className="mt-4 font-heading text-5xl uppercase leading-none tracking-[-0.019em] md:text-7xl xl:text-[128px]">
+        <h1 className="mt-4 font-heading text-8xl uppercase leading-none tracking-[-0.019em] md:text-9xl">
           Built For Every Player
-        </h2>
+        </h1>
 
         <div className="mt-6 text-base md:text-[19px]">
           <p>
@@ -25,7 +25,7 @@ export function WhoWeAre() {
         </div>
       </div>
 
-      <div className="mt-29">
+      <div className="mt-24">
         <StatsCards />
       </div>
     </section>

--- a/src/components/WhoWeAre/WhoWeAre.tsx
+++ b/src/components/WhoWeAre/WhoWeAre.tsx
@@ -8,7 +8,7 @@ export function WhoWeAre() {
           Who We Are
         </p>
 
-        <h1 className="mt-4 font-heading text-8xl uppercase leading-none tracking-[-0.019em] md:text-9xl">
+        <h1 className="mt-4 font-heading text-8xl uppercase leading-none tracking-[-0.019em] md:text-8xl">
           Built For Every Player
         </h1>
 
@@ -25,7 +25,7 @@ export function WhoWeAre() {
         </div>
       </div>
 
-      <div className="mt-24">
+      <div className="mt-18">
         <StatsCards />
       </div>
     </section>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,8 +18,8 @@ const buttonVariants = cva(
         cta: "border-brand-navy bg-brand-navy text-brand-yellow hover:bg-transparent hover:text-brand-navy",
       },
       size: {
-        sm: "h-[36px] gap-2.5 py-1.5 px-[24px] text-[0.8rem] rounded-[30px]",
-        md: "h-[50px] gap-2.5 py-2.5 px-[30px] text-xl rounded-[30px]",
+        sm: "h-8 gap-2 py-1 px-5 text-xs rounded-full",
+        md: "h-11 gap-2 py-2 px-6 text-base rounded-full",
         icon: "size-8",
         "icon-xs":
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",

--- a/src/components/ui/textbox.tsx
+++ b/src/components/ui/textbox.tsx
@@ -4,7 +4,7 @@ import type * as React from "react"
 import { cn } from "@/lib/utils"
 
 const textboxVariants = cva(
-  "w-full rounded-xl border-1 bg-white px-4 py-3 font-body text-xl transition-colors duration-200 ease-in-out focus:outline-none",
+  "w-full rounded-xl border-1 bg-white px-4 py-2 font-body text-base transition-colors duration-200 ease-in-out focus:outline-none",
   {
     variants: {
       state: {


### PR DESCRIPTION
# Description

This PR rescales spacing, typography, and component sizing across most of the frontend to extend the smaller, more consistent visual language introduced for `Navbar`/`Footer`/`EventCard` in #108, and migrates the effort away from arbitrary pixel values entirely in favor of Tailwind's built-in utility scale (including bare-number spacing utilities like `pt-30`, `gap-14`, and `h-42`, which Tailwind v4 resolves as clean quarter-rem multiples rather than magic numbers).

### Homepage sections

- scales down `SocialSessions` headings, spacing, and photos, adds a second intro line, and tightens the card gap (also fixes the card-wrapper width so the gap renders correctly)
- scales down `StatCard`/`StatsCards` sizing and matches the "Built For Every Player" heading to the `SocialSessions` heading size, then resizes the cards further and tightens the gap above them
- adjusts `WhoWeAre` section padding/gap to match
- matches the `HomepageFaq` heading size to `SocialSessions` and adds top spacing
- makes the `HomepageFaq` accordion column fill the container (a fixed-px grid column was previously causing uneven left/right padding) and tightens the gap to the sidebar
- equalizes `HomepageFaq` top/bottom section padding and centers the heading+grid block so the "Still have questions" sidebar sits closer to the middle instead of flush right
- replaces a hand-styled `Link` in `HomepageFaq` that duplicated the `Button` component's styling with the actual shared `Button` primitive

### Events page

- resizes `EventCard` using Tailwind's utility scale instead of raw px values, un-bolds the card title, matches the Upcoming/Past Events headings to the `SocialSessions` size, and adds intro descriptions under each heading
- fixes a card-row alignment bug where partial rows after "Load more" misaligned due to shrink-to-fit width ambiguity on the flex-wrap container (fixed with explicit `w-full` plus restoring `justify-center`)
- reworks the events page top/bottom spacing to balance against the navbar/footer height
- fixes the past-variant `EventCard` title/date color (`text-secondary-foreground` -> `text-brand-primary`) to match the "Past Events" heading color

### About & FAQ pages

- matches the `about` page heading/description sizing to the events page pattern, widens the description to ~5 lines, and adds more space before the footer
- aligns the `about` page top spacing and heading/description gap to the events pattern
- matches the `faq` page heading size/top spacing to the other pages and adds an intro description

### Navbar

- fixes the nav link `>` indicator to only show on hover, not permanently on the active page (removes the `isActive` branch driving it)

### Login & shared UI primitives

- fixes the login page's full-viewport `min-height` calc to correctly account for navbar height (previously let the footer overlap/crowd the login form)
- resizes the `Login` card
- scales down the shared `Button` and `Textbox` primitives in `src/components/ui/` for consistent form text sitewide

Note that the `Button` and `Textbox` changes touch shared primitives in `src/components/ui/` used well beyond the login page — the events "Load more" buttons, `SocialSessions` CTA, and `EventCard` CTA all render through these components, so verify sizing on those surfaces too, not just `/log-in`.

Not related to a ticket.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member