### PR TITLE
chore(frontend): align description text sizes and heading tracking

### DIFF
--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -19,7 +19,7 @@ export default async function AboutPage() {
   return (
     <div className="flex flex-col items-center gap-8 bg-background px-6 pt-12 pb-24">
       <section className="flex flex-col items-center gap-6">
-        <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
+        <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase md:text-8xl">
           About
         </h1>
         {/* Placeholder hardcoded text - no payload collection for about page text */}

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -52,7 +52,7 @@ export default async function EventsPage({
   return (
     <div className="flex flex-col items-center gap-20 bg-background px-6 pt-12 pb-32">
       <section className="flex flex-col items-center gap-6">
-        <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
+        <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase md:text-8xl">
           Upcoming Events
         </h1>
 
@@ -82,7 +82,7 @@ export default async function EventsPage({
       </section>
 
       <section className="flex flex-col items-center gap-6">
-        <h2 className="mt-18 mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
+        <h2 className="mt-18 mb-0 text-center font-heading text-8xl text-brand-primary uppercase md:text-8xl">
           Past Events
         </h2>
 

--- a/src/app/(frontend)/faq/page.tsx
+++ b/src/app/(frontend)/faq/page.tsx
@@ -19,7 +19,7 @@ export default async function FaqPage() {
 
   return (
     <main className="flex flex-col items-center gap-6 px-6 pt-12 pb-20">
-      <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
+      <h1 className="mb-0 text-center font-heading text-8xl text-brand-primary uppercase md:text-8xl">
         FAQ
       </h1>
       <p className="mb-16 max-w-lg text-center font-body text-brand-primary text-sm md:text-base">

--- a/src/app/(frontend)/log-in/page.tsx
+++ b/src/app/(frontend)/log-in/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <div className="flex min-h-[calc(100svh-82px)] flex-col items-center justify-center gap-12 px-6 pt-12 pb-28">
-      <h1 className="text-center font-heading text-8xl text-brand-primary uppercase tracking-wide md:text-8xl">
+      <h1 className="text-center font-heading text-8xl text-brand-primary uppercase md:text-8xl">
         Login
       </h1>
       <Login />

--- a/src/app/(frontend)/sign-up/page.tsx
+++ b/src/app/(frontend)/sign-up/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 export default function SignUpPage() {
   return (
     <main className="flex flex-col items-center px-6 py-20">
-      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase sm:text-8xl">
         Sign Up
       </h1>
     </main>

--- a/src/app/(frontend)/social-sessions/[id]/checkout/cancelled/page.tsx
+++ b/src/app/(frontend)/social-sessions/[id]/checkout/cancelled/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 export default function CheckoutCancelledPage() {
   return (
     <main className="flex flex-col items-center px-6 py-20">
-      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase sm:text-8xl">
         Checkout Cancelled
       </h1>
     </main>

--- a/src/app/(frontend)/social-sessions/[id]/checkout/success/page.tsx
+++ b/src/app/(frontend)/social-sessions/[id]/checkout/success/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 export default function CheckoutSuccessPage() {
   return (
     <main className="flex flex-col items-center px-6 py-20">
-      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase tracking-wide sm:text-8xl">
+      <h1 className="text-center font-heading text-6xl text-brand-primary uppercase sm:text-8xl">
         Checkout Successful
       </h1>
     </main>

--- a/src/components/HomepageFaq/HomepageFaq.tsx
+++ b/src/components/HomepageFaq/HomepageFaq.tsx
@@ -43,11 +43,11 @@ export default function HomepageFaq({ items }: HomepageFaqProps) {
             <div className="max-w-[257px] text-brand-primary">
               <h3 className="mb-9 font-black text-xl uppercase">Still have questions?</h3>
 
-              <p className="mb-6 text-xl leading-normal">
+              <p className="mb-6 text-sm leading-normal md:text-base">
                 If there's anything we haven't covered that you would like to ask, please reach out!
               </p>
 
-              <p className="text-xl leading-normal">
+              <p className="text-sm leading-normal md:text-base">
                 Message us through Email, Instagram, TikTok or Discord provided below.
               </p>
             </div>

--- a/src/components/WhoWeAre/WhoWeAre.tsx
+++ b/src/components/WhoWeAre/WhoWeAre.tsx
@@ -12,7 +12,7 @@ export function WhoWeAre() {
           Built For Every Player
         </h1>
 
-        <div className="mt-6 text-base md:text-[19px]">
+        <div className="mt-6 text-sm md:text-base">
           <p>
             The University of Auckland Volleyball Club caters to players of all skill levels – even
             those outside UoA.


### PR DESCRIPTION
# Description

This PR fixes visual inconsistencies between the homepage sections and the rest of the site that were introduced during the earlier component rescaling work in #138.

- matches the `WhoWeAre` "Built For Every Player" description text size to `SocialSessions`' description pattern (`text-base md:text-[19px]` → `text-sm md:text-base`), removing the arbitrary bracket value
- matches the `HomepageFaq` "Still have questions?" paragraphs to the same `text-sm md:text-base` pattern (previously a static `text-xl` with no responsive step)
- removes `tracking-wide` from headings on the About, Events (`Upcoming Events` and `Past Events`), FAQ, Login, Sign Up, and social-sessions checkout success/cancelled pages so their letter-spacing matches the homepage headings (`SocialSessions` and `HomepageFaq`), which use the default (tighter) spacing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member