### PR TITLE
chore(exec-card): match text sizing/color to toggle pills

### DIFF
--- a/src/components/ExecCard/ExecCard.tsx
+++ b/src/components/ExecCard/ExecCard.tsx
@@ -25,7 +25,7 @@ export default function ExecCard({
 
   return (
     <article className="mx-auto flex w-full max-w-[220px] flex-col items-center text-center">
-      <p className="mb-3 min-h-10 max-w-full break-words text-center font-body font-bold text-brand-primary text-sm uppercase tracking-wide sm:min-h-12 sm:text-base">
+      <p className="mb-3 min-h-10 max-w-full break-words text-center font-body font-bold text-brand-primary text-lg uppercase tracking-wide sm:min-h-12 sm:text-xl">
         {role}
       </p>
 
@@ -47,12 +47,10 @@ export default function ExecCard({
         <p className="font-body text-brand-primary text-sm leading-snug">{degree}</p>
       ) : null}
       {position ? (
-        <p className="font-body font-semibold text-brand-primary text-sm leading-snug">
-          {position}
-        </p>
+        <p className="mt-1 font-body text-brand-primary text-sm leading-snug">{position}</p>
       ) : null}
       {typeof yearsOfExperience === "number" ? (
-        <p className="font-body text-brand-navy text-sm leading-snug">
+        <p className="mt-1 font-body text-brand-primary text-sm leading-snug">
           {yearsOfExperience} years exp.
         </p>
       ) : null}

--- a/src/components/ExecutivesGrid/ExecutivesGrid.tsx
+++ b/src/components/ExecutivesGrid/ExecutivesGrid.tsx
@@ -65,7 +65,7 @@ export default function ExecutivesGrid({ executives }: { executives: Executive[]
 
         return (
           <section className="mx-auto max-w-fit" key={section}>
-            <h2 className="mb-8 text-center font-heading text-2xl text-brand-primary uppercase sm:text-3xl">
+            <h2 className="mb-4 text-center font-heading text-[2.75rem] text-brand-primary uppercase">
               {section}
             </h2>
 


### PR DESCRIPTION
# Description

This PR fixes text sizing and color inconsistencies in the Executives section of the About page.

- resizes the role-group headings (`CO-PRESIDENTS`, `ADMIN TEAM`, `SOCIAL MEDIA & MARKETING`, `EXECUTIVE TEAM`) in `ExecutivesGrid.tsx` from `text-2xl sm:text-3xl` to `text-[2.75rem]` to match the `Executives`/`Comp Team` toggle pill text size in `TogglePillGroup.tsx`
  - drops the `sm:text-3xl` responsive step since the toggle pills don't have one either
  - reduces the heading's `mb-8` to `mb-4` to tighten the gap to the exec cards below
- resizes the role label in `ExecCard.tsx` (e.g. `SENIOR ADVISOR`, `TREASURER`) from `text-sm sm:text-base` to `text-lg sm:text-xl` to match the name text size
- removes `font-semibold` from the position line so it matches the weight of the degree and years-of-experience lines
- recolors the years-of-experience line from `text-brand-navy` to `text-brand-primary` to match the degree and position lines
- adds `mt-1` spacing between the degree, position, and years-of-experience lines, which previously had no gap between them at all

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member