### PR TITLE
chore(accordion): fix conflicting text-size classes on answer content

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -69,7 +69,7 @@ function AccordionContent({
 }: React.ComponentProps<typeof AccordionPrimitive.Content>) {
   return (
     <AccordionPrimitive.Content
-      className="text-[20px] text-sm data-closed:animate-accordion-up data-open:animate-accordion-down"
+      className="text-sm data-closed:animate-accordion-up data-open:animate-accordion-down md:text-base"
       data-slot="accordion-content"
       {...props}
     >


### PR DESCRIPTION
# Description

This PR fixes conflicting text-size classes on the `AccordionContent` answer text in `accordion.tsx`. The className previously set both a literal `text-[20px]` and Tailwind's `text-sm` on the same element, where `text-sm` always won and made the `text-[20px]` dead code. This is replaced with `text-sm md:text-base` so the answer text scales responsively instead of carrying an unused, contradictory size utility.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I've requested a review from another team member
